### PR TITLE
adding support for custom configmaps,secrets

### DIFF
--- a/charts/port-k8s-exporter/templates/configmap.yaml
+++ b/charts/port-k8s-exporter/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.configMap.create true -}}
 {{- $config := default (uuidv4 | replace "-" "") .Values.stateKey -}}
 {{- $config_lookup := (lookup "v1" "ConfigMap" .Release.Namespace (include "port-k8s-exporter.configMapName" .)) -}}
 {{- if $config_lookup -}}
@@ -26,3 +27,4 @@ data:
       {{- required "config.yaml is required" .Values.configMap.config | toYaml | nindent 4 }}
     {{ end }}
   state_key: {{ $config }}
+{{- end }}

--- a/charts/port-k8s-exporter/templates/secret.yaml
+++ b/charts/port-k8s-exporter/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.secret.useExistingSecret false }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,3 +13,4 @@ type: opaque
 data:
   PORT_CLIENT_ID: {{ required "Port Client ID is required" .Values.secret.secrets.portClientId | b64enc }}
   PORT_CLIENT_SECRET: {{ required "Port Client Secret is required" .Values.secret.secrets.portClientSecret | b64enc }}
+{{- end }}

--- a/charts/port-k8s-exporter/values.yaml
+++ b/charts/port-k8s-exporter/values.yaml
@@ -19,11 +19,15 @@ secret:
   secrets:
     portClientId: ""
     portClientSecret: ""
+  # secret.useExistingSecret -- Enable this if you wish to create your own secret with credentials.
+  useExistingSecret: false
 
 configMap:
   annotations: {}
-  name: ""
   config:
+  name: ""
+  # configMap.create -- Disable to specify your own configmap to be used.
+  create: true
 
 serviceAccount:
   create: true


### PR DESCRIPTION
This PR is intended to add support for custom configmaps and secrets.  We leverage `kustomize` and their `configmapgenerator` and `external-secrets` to create these resources outside of helm's purview.  As a result, I needed a way to NOT create the configmap or secret as currently defined.

This is designed to be a noop with existing implementations as both options should default to "off" essentially.