### PR TITLE
Port chart fix suggestion

### DIFF
--- a/charts/port-agent/Chart.yaml
+++ b/charts/port-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-agent
 description: A Helm chart for Port Agent
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: "v0.3.0"
 home: https://getport.io/
 sources:

--- a/charts/port-agent/templates/_helpers.tpl
+++ b/charts/port-agent/templates/_helpers.tpl
@@ -61,6 +61,7 @@ Create the name of the secret to use
 Create the list of environment variables
 */}}
 {{- define "port-agent.envVariables"}}
+{{- if eq .Values.secret.useExistingSecret false }}
 {{- range $key, $val := .Values.env.secret }}
 - name: {{ $key }}
   valueFrom:
@@ -68,6 +69,7 @@ Create the list of environment variables
       name: {{ include "port-agent.secretName" $ }}
       key: {{ $key }}
 {{- end}}
+{{- end }}
 {{- range $key, $val := .Values.env.normal }}
 - name: {{ $key }}
   value: {{ $val | quote }}

--- a/charts/port-agent/templates/deployment.yaml
+++ b/charts/port-agent/templates/deployment.yaml
@@ -32,6 +32,11 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             {{- include "port-agent.envVariables" . | indent 12 }}
+          {{- if eq .Values.secret.useExistingSecret true }}
+          envFrom:
+            - secretRef:
+                name: {{ include "port-agent.secretName" . }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
 


### PR DESCRIPTION
The range below is a bit confusing as it iterates the keys which has empty values (while the values themselves are coming from an already existing secret). This can be misleading IMHO.

```
{{- range $key, $val := .Values.env.secret }}
- name: {{ $key }}
  valueFrom:
    secretKeyRef:
      name: {{ include “port-agent.secretName” $ }}
      key: {{ $key }}
```

My suggestion is to use the same condition that's being used in secret.yaml and load all keys from existing secret using `envFrom`.