### PR TITLE
feat(kubeconfig): add options to cfg a kubeconfig to connect external cluster

### DIFF
--- a/charts/port-k8s-exporter/Chart.yaml
+++ b/charts/port-k8s-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-k8s-exporter
 description: A Helm chart for Port Kubernetes Exporter
 type: application
-version: 0.1.20
+version: 0.2.0
 appVersion: "0.1.14"
 home: https://getport.io/
 sources:

--- a/charts/port-k8s-exporter/README.md
+++ b/charts/port-k8s-exporter/README.md
@@ -81,6 +81,10 @@ The following table lists the configuration parameters of the `port-k8s-exporter
 | `nodeSelector`                        | NodeSelector applied to the pod                                                                      | `{}`                                  |
 | `tolerations`                         | Tolerations applied to the pod                                                                       | `[]`                                  |
 | `affinity`                            | Affinity applied to the pod                                                                          | `{}`                                  |
+| `extraEnv`                            | extraEnv applied to the pod                                                                          | `[]`                                  |
+| `extraObjects`                        | extraObjects applied to the namespace                                                                | `[]`                                  |
+| `extraVolumes`                        | extraVolumes applied to the pod                                                                      | `[]`                                  |
+| `extraVolumeMounts`                   | extraVolumeMounts applied to the pod                                                                 | `[]`                                  |
 
 To override values in `helm install`, use either the `--set` flag or the `--set-file` flag to set individual values from a file.
 

--- a/charts/port-k8s-exporter/templates/deployment.yaml
+++ b/charts/port-k8s-exporter/templates/deployment.yaml
@@ -54,13 +54,22 @@ spec:
                 configMapKeyRef:
                   name: {{ include "port-k8s-exporter.configMapName" . }}
                   key: state_key
+          {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config-volume
               mountPath: "/config"
+            {{- with .Values.extraVolumeMounts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
       volumes:
         - name: config-volume
           configMap:
             name: {{ include "port-k8s-exporter.configMapName" . }}
+        {{- with .Values.extraVolumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/port-k8s-exporter/templates/extra-manifests.yaml
+++ b/charts/port-k8s-exporter/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/charts/port-k8s-exporter/values.yaml
+++ b/charts/port-k8s-exporter/values.yaml
@@ -59,3 +59,24 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+extraEnv: []
+  # - name: "KUBECONFIG"
+  #   value: /tmp/.kube/config
+
+extraObjects: []
+# - apiVersion: v1
+#   kind: Secret
+#   metadata:
+#     name: kubeconfig
+#   type: Opaque
+#   stringData:
+
+extraVolumes: []
+  # - name: kubeconfig
+  #   secret:
+  #     secretName: kubeconfig
+
+extraVolumeMounts: []
+  # - name: kubeconfig
+  #   mountPath: "/tmp/.kube"


### PR DESCRIPTION
With this pull request, we are enhancing the Helm chart for `port-k8s-exporter`. 

Now, you have the option to define four new keys in the values.yaml file for `extraVolumeMounts`, `extraVolumes`, `extraObjects`, and `extraEnvs`. 

Please review the provided configuration, as we have verified that port-k8s-exporter is successfully connecting to an external cluster.


```
extraEnv:
  - name: "KUBECONFIG"
    value: /tmp/.kube/config

extraObjects:
- apiVersion: v1
  kind: Secret
  metadata:
    name: mcp-kubeconfig
  type: Opaque
  stringData:
    config: |
      apiVersion: v1
      clusters:
      - cluster:
          server: https://proxy.xxx.io/v1/k8s
        name: upbound-caas-env
      contexts:
      - context:
          cluster: upbound-caas-env
          user: upbound-caas-env
        name: upbound-caas-env
      current-context: upbound-caas-env
      kind: Config
      preferences: {}
      users:
      - name: upbound-caas-env
        user:
          token: $token

extraVolumes:
  - name: kubeconfig
    secret:
      secretName: mcp-kubeconfig

extraVolumeMounts:
  - name: kubeconfig
    mountPath: "/tmp/.kube"
```