### PR TITLE
bump agent to 0.6.2

### DIFF
--- a/charts/port-agent/Chart.yaml
+++ b/charts/port-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: port-agent
 description: A Helm chart for Port Agent
 type: application
-version: 0.6.1
-appVersion: "v0.6.1"
+version: 0.6.2
+appVersion: "v0.6.2"
 home: https://getport.io/
 sources:
   - https://github.com/port-labs/port-agent


### PR DESCRIPTION
agnt 0.6.2 adds log about the response for the request outgoing from the agent to the third party