### PR TITLE
Added manifests for self-signed certificate

### DIFF
--- a/charts/port-ocean/README.md
+++ b/charts/port-ocean/README.md
@@ -91,8 +91,8 @@ Alternatively, you can use a YAML file that specifies the values while installin
 
 
 ### Self-signed certificate trust
-For self-hosted integrations with self-signed certificates, you will need to add your CA to the integration's OS. 
-To do so, you will need to run the install command with the following flags:
+For self-hosted 3rd-party applications, with self-signed certificates, you will need to add your CA to the integration's configuration. 
+To do so, you will need to run the `helm install` command with the following flags:
 
 ```sh
 helm install my-ocean-integration port-labs/port-ocean \

--- a/charts/port-ocean/README.md
+++ b/charts/port-ocean/README.md
@@ -91,7 +91,7 @@ Alternatively, you can use a YAML file that specifies the values while installin
 
 
 ### Self-signed certificate trust
-For self-hosted 3rd-party applications, with self-signed certificates, you will need to add your CA to the integration's configuration. 
+For self-hosted 3rd-party applications with self-signed certificates, you will need to add your CA to the integration's configuration. 
 To do so, you will need to run the `helm install` command with the following flags:
 
 ```sh

--- a/charts/port-ocean/README.md
+++ b/charts/port-ocean/README.md
@@ -77,6 +77,8 @@ The following table lists the configuration parameters of the `port-ocean` chart
 | `integration.type`         | Type of the integration. i.e (`pager-duty`)                                                                                                                                                                                                                                                                                                                                                                                                                                                        | `""`                        |
 | `integration.config`       | Configuration for the integration.                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | `{}`                        |
 | `integration.secrets`      | Secrets for the integration (irrelevant if secret.useExistingSecret=true).                                                                                                                                                                                                                                                                                                                                                                                                                         | `{}`                        |
+| `integration.selfSignedCertificate.enabled`      | Enable self-signed certificate trust for the integration.                                                                                                                                                                                                                                                                                                                                                                                                                       | `false`                        |
+| `integration.selfSignedCertificate.certificate`      |  The value of the self-signed certificate (only when `integration.selfSignedCertificate.enabled=true`)                                                                                                                                                                                                                                                                                                                                                                                                                        | `""`                        |
 | `eventListener.type`       | Type of the event listener for the integration, one of the following "WEBHOOK" / "KAFKA" / "SAMPLE"                                                                                                                                                                                                                                                                                                                                                                                                | `"KAFKA"`                   |
 
 To override values in `helm install`, use either the `--set` flag.
@@ -86,3 +88,18 @@ Alternatively, you can use a YAML file that specifies the values while installin
     helm install my-ocean-integration port-labs/port-ocean \
        --create-namespace --namespace port-ocean \
        -f custom_values.yaml
+
+
+### Self-signed certificate trust
+For self-hosted integrations with self-signed certificates, you will need to add your CA to the integration's OS. 
+To do so, you will need to run the install command with the following flags:
+
+```sh
+helm install my-ocean-integration port-labs/port-ocean \
+   --create-namespace --namespace port-ocean \
+   -f custom_values.yaml \ 
+   # Flag for enabling self signed certificates
+   --set integration.selfSignedCertificate.enabled=true \ 
+   # Flag for passing the certificate file
+   --set-file integration.selfSignedCertificate.certificate=/PATH/TO/CERTIFICATE.crt
+```

--- a/charts/port-ocean/templates/_helpers.tpl
+++ b/charts/port-ocean/templates/_helpers.tpl
@@ -104,3 +104,11 @@ Get deployment name per integration
 {{ $prefix:= include "port-ocean.metadataNamePrefix" . }}
 {{- printf "%s-deployment" $prefix }}
 {{- end }}
+
+{{/*
+Get self signed cert secret name
+*/}}
+{{- define "port-ocean.selfSignedCertName" -}}
+{{ $prefix:= include "port-ocean.metadataNamePrefix" . }}
+{{- printf "%s-cert" $prefix }}
+{{- end }}

--- a/charts/port-ocean/templates/certificate_secret.yaml
+++ b/charts/port-ocean/templates/certificate_secret.yaml
@@ -2,9 +2,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "port-ocean.selfSignedCertName" }}
-type: kubernetes.io/tls
+  name: {{ include "port-ocean.selfSignedCertName" . }}
+type: Opaque
 data:
-  tls.crt: {{ .Values.integration.selfSignedCertificate.certificate | b64enc | quote }}
-  tls.key: {{ .Values.integration.selfSignedCertificate.privateKey | b64enc | quote }}
+  crt: {{ .Values.integration.selfSignedCertificate.certificate | b64enc }}
 {{- end }}

--- a/charts/port-ocean/templates/certificate_secret.yaml
+++ b/charts/port-ocean/templates/certificate_secret.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.integration.selfSignedCertificate.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "port-ocean.selfSignedCertName" }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .Values.integration.selfSignedCertificate.certificate | b64enc | quote }}
+  tls.key: {{ .Values.integration.selfSignedCertificate.privateKey | b64enc | quote }}
+{{- end }}

--- a/charts/port-ocean/templates/deployment.yaml
+++ b/charts/port-ocean/templates/deployment.yaml
@@ -26,6 +26,25 @@ spec:
               name: {{ include "port-ocean.configMapName" . }}
           - secretRef:
               name: {{ include "port-ocean.secretName" . }}
+        volumeMounts:
+        {{- if .Values.integration.selfSignedCertificate.enabled }}
+          - name: certificates
+            mountPath: /usr/local/share/ca-certificates
+            readOnly: true
+        {{- end }}
+      volumes:
+        {{- if .Values.integration.selfSignedCertificate.enabled }}
+        - name: certificates
+          projected:
+            sources:
+              - secret:
+                  name: {{ include "port-ocean.selfSignedCertName" }}
+                  items:
+                    - key: tls.crt
+                      path: tls.crt
+                    - key: tls.key
+                      path: tls.key
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
       {{- toYaml . | nindent 8 }}

--- a/charts/port-ocean/templates/deployment.yaml
+++ b/charts/port-ocean/templates/deployment.yaml
@@ -29,7 +29,8 @@ spec:
         volumeMounts:
         {{- if .Values.integration.selfSignedCertificate.enabled }}
           - name: certificates
-            mountPath: /usr/local/share/ca-certificates
+            mountPath: /etc/ssl/certs/cert.pem
+            subPath: cert.pem
             readOnly: true
         {{- end }}
       volumes:
@@ -38,12 +39,10 @@ spec:
           projected:
             sources:
               - secret:
-                  name: {{ include "port-ocean.selfSignedCertName" }}
+                  name: {{ include "port-ocean.selfSignedCertName" . }}
                   items:
-                    - key: tls.crt
-                      path: tls.crt
-                    - key: tls.key
-                      path: tls.key
+                    - key: crt
+                      path: cert.pem
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/port-ocean/values.yaml
+++ b/charts/port-ocean/values.yaml
@@ -52,3 +52,6 @@ integration:
   eventListener:
     type: "KAFKA"
     brokers: "b-1-public.publicclusterprod.t9rw6w.c1.kafka.eu-west-1.amazonaws.com:9196,b-2-public.publicclusterprod.t9rw6w.c1.kafka.eu-west-1.amazonaws.com:9196,b-3-public.publicclusterprod.t9rw6w.c1.kafka.eu-west-1.amazonaws.com:9196"
+  selfSignedCertificate:
+    enabled: false
+    certificate: ""


### PR DESCRIPTION
Added support for self-signed certificate support in Ocean.

This version will allow to pass the `--set integration.selfSignedCertificate.enabled=true --set-file integration.selfSignedCertificate.certificate=SelfSignedFilePath.crt` to add self signed certificate to the trusted store in the integration.