### PR TITLE
Fix port ocean secret generation fails on number as string secret

### DIFF
--- a/charts/port-ocean/Chart.yaml
+++ b/charts/port-ocean/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-ocean
 description: A Helm chart for Port Ocean integrations
 type: application
-version: 0.1.10
+version: 0.1.11
 appVersion: "0.1.0"
 home: https://getport.io/
 sources:

--- a/charts/port-ocean/templates/secret.yaml
+++ b/charts/port-ocean/templates/secret.yaml
@@ -12,7 +12,7 @@ data:
   {{- if .Values.integration.secrets }}
   {{- range $key, $value := .Values.integration.secrets }}
   OCEAN__INTEGRATION__CONFIG__{{ $key | snakecase | upper }}:
-    {{ if kindIs "map" $value }}{{ $value | toJson | b64enc | quote }}{{ else }}{{ $value | b64enc | quote }}{{ end }}
+    {{ if kindIs "map" $value }}{{ $value | toJson | b64enc | quote }}{{ else }}{{ $value | toString | b64enc | quote }}{{ end }}
   {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
when installing newrelic integration, the newRelicAccountId is of type string, while the actual value from newRelic is number e.g "12345", when passing it as "12345" helm was parsing it to a number which then caused the helm install to fail when trying to encode the value.

Adding `toString` solved the issue.