### PR TITLE
Support tls config in ingress for port-ocean

### DIFF
--- a/charts/port-ocean/templates/ingress.yaml
+++ b/charts/port-ocean/templates/ingress.yaml
@@ -28,5 +28,9 @@ spec:
                         name: {{ include "port-ocean.serviceName" . }}
                         port:
                             number: {{ .Values.service.port }}
+    {{- if .Values.ingress.tls }}
+    tls:
+      {{- toYaml .Values.ingress.tls | nindent 6 }}
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/port-ocean/values.yaml
+++ b/charts/port-ocean/values.yaml
@@ -64,7 +64,11 @@ ingress:
   host: null
   path: /
   pathType: Prefix
-
+  tls: []
+  # Example
+  #   - secretName: my-secret
+  #     hosts:
+  #       - "my-host.my-domain.com"
   
 integration:
   identifier: ""


### PR DESCRIPTION
Add support for adding tls config settings as part of the Ingress manifest used as part of the port-ocean helm chart