### PR TITLE
changed default eventlistener to polling

### DIFF
--- a/charts/port-k8s-exporter/Chart.yaml
+++ b/charts/port-k8s-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-k8s-exporter
 description: A Helm chart for Port Kubernetes Exporter
 type: application
-version: 0.2.11
+version: 0.2.12
 appVersion: "0.2.10"
 home: https://getport.io/
 sources:

--- a/charts/port-k8s-exporter/values.yaml
+++ b/charts/port-k8s-exporter/values.yaml
@@ -18,13 +18,12 @@ nameOverride: ""
 fullnameOverride: ""
 
 eventListener:
-  type: "KAFKA"
-  brokers: "b-1-public.publicclusterprod.t9rw6w.c1.kafka.eu-west-1.amazonaws.com:9196,b-2-public.publicclusterprod.t9rw6w.c1.kafka.eu-west-1.amazonaws.com:9196,b-3-public.publicclusterprod.t9rw6w.c1.kafka.eu-west-1.amazonaws.com:9196"
-  securityProtocol: "SASL_SSL"
-  authenticationMechanism: "SCRAM-SHA-512"
-# type: "POLLING"
-# pollingRate: 60
-
+  type: "POLLING"
+  pollingRate: 60
+  # type: "KAFKA"
+  # brokers: "b-1-public.publicclusterprod.t9rw6w.c1.kafka.eu-west-1.amazonaws.com:9196,b-2-public.publicclusterprod.t9rw6w.c1.kafka.eu-west-1.amazonaws.com:9196,b-3-public.publicclusterprod.t9rw6w.c1.kafka.eu-west-1.amazonaws.com:9196"
+  # securityProtocol: "SASL_SSL"
+  # authenticationMechanism: "SCRAM-SHA-512"
 secret:
   annotations: {}
   name: ""


### PR DESCRIPTION
# Description

What - changed default eventlistener to polling
Why - so users won't need kafka for a regular port-k8s-exporter installation
How - helm chart default values

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

