### PR TITLE
Change the default brokers for k8s exporter

### DIFF
--- a/charts/port-k8s-exporter/Chart.yaml
+++ b/charts/port-k8s-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-k8s-exporter
 description: A Helm chart for Port Kubernetes Exporter
 type: application
-version: 0.2.13
+version: 0.2.14
 appVersion: "0.2.11"
 home: https://getport.io/
 sources:

--- a/charts/port-k8s-exporter/values.yaml
+++ b/charts/port-k8s-exporter/values.yaml
@@ -20,10 +20,11 @@ fullnameOverride: ""
 eventListener:
   type: "POLLING"
   pollingRate: 60
+  # ---- KAFKA CONFIGURATION ----
   # type: "KAFKA"
-  # brokers: "b-1-public.publicclusterprod.t9rw6w.c1.kafka.eu-west-1.amazonaws.com:9196,b-2-public.publicclusterprod.t9rw6w.c1.kafka.eu-west-1.amazonaws.com:9196,b-3-public.publicclusterprod.t9rw6w.c1.kafka.eu-west-1.amazonaws.com:9196"
-  # securityProtocol: "SASL_SSL"
-  # authenticationMechanism: "SCRAM-SHA-512"
+  brokers: "b-1-public.publicclusterprod.t9rw6w.c1.kafka.eu-west-1.amazonaws.com:9196,b-2-public.publicclusterprod.t9rw6w.c1.kafka.eu-west-1.amazonaws.com:9196,b-3-public.publicclusterprod.t9rw6w.c1.kafka.eu-west-1.amazonaws.com:9196"
+  securityProtocol: "SASL_SSL"
+  authenticationMechanism: "SCRAM-SHA-512"
 secret:
   annotations: {}
   name: ""


### PR DESCRIPTION
# Description

What - The k8s exporter defaults for the local broker
Why - wrong default configuration
How - passing env vars from the chart in any case

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

