### PR TITLE
removed redundant labels

### DIFF
--- a/charts/port-k8s-exporter/Chart.yaml
+++ b/charts/port-k8s-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-k8s-exporter
 description: A Helm chart for Port Kubernetes Exporter
 type: application
-version: 0.2.17
+version: 0.2.18
 appVersion: "0.2.12"
 home: https://getport.io/
 sources:

--- a/charts/port-k8s-exporter/templates/deployment.yaml
+++ b/charts/port-k8s-exporter/templates/deployment.yaml
@@ -16,7 +16,6 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "port-k8s-exporter.selectorLabels" . | nindent 8 }}
         {{- include "port-k8s-exporter.labels" . | nindent 8 }}
         config-hash: {{ .Values.configMap.config | toYaml | sha256sum | trunc 32 }}
     spec:


### PR DESCRIPTION
# Description

What - The chart is failing
Why - The selector labels are duplicated in the labels define and later in the deployment labels after including the other labels
How - removed the selector labels and using the one that are already in the labels define

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
