### PR TITLE
added extraLabels to allow setting labels to the deployments

### DIFF
--- a/charts/port-agent/templates/_helpers.tpl
+++ b/charts/port-agent/templates/_helpers.tpl
@@ -40,6 +40,9 @@ helm.sh/chart: {{ include "port-agent.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- range $key, $value := .Values.extraLabels }}
+{{$key}}: {{ $value }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/port-agent/templates/deployment.yaml
+++ b/charts/port-agent/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "port-agent.selectorLabels" . | nindent 8 }}
+        {{- include "port-agent.labels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/port-agent/values.yaml
+++ b/charts/port-agent/values.yaml
@@ -3,13 +3,13 @@ image:
   pullPolicy: IfNotPresent
   tag: ""
 
-imagePullSecrets: [ ]
+imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
 controlThePayloadConfig: ""
 secret:
-  annotations: { }
+  annotations: {}
   name: ""
   useExistingSecret: false
 
@@ -27,21 +27,21 @@ env:
     PORT_CLIENT_ID: ""
     PORT_CLIENT_SECRET: ""
 
-extraLabels: { }
+extraLabels: {}
 
-podAnnotations: { }
+podAnnotations: {}
 
-podSecurityContext: { }
-  # Example
+podSecurityContext: {}
+# Example
   # runAsGroup: 1001
   # runAsUser: 1001
   # fsGroup: 1001
-# fsGroupChangePolicy: "OnRootMismatch"
-containerSecurityContext: { }
-  # Example
+  # fsGroupChangePolicy: "OnRootMismatch"
+containerSecurityContext: {}
+# Example
   # runAsGroup: 1001
   # runAsUser: 1001
-# allowPrivilegeEscalation: false
+  # allowPrivilegeEscalation: false
 
 rolloutStrategy: "Recreate"
 
@@ -53,11 +53,11 @@ resources:
     memory: "256Mi"
     cpu: "200m"
 
-nodeSelector: { }
+nodeSelector: {}
 
-tolerations: [ ]
+tolerations: []
 
-affinity: { }
+affinity: {}
 
 selfSignedCertificate:
   enabled: false

--- a/charts/port-agent/values.yaml
+++ b/charts/port-agent/values.yaml
@@ -3,13 +3,13 @@ image:
   pullPolicy: IfNotPresent
   tag: ""
 
-imagePullSecrets: []
+imagePullSecrets: [ ]
 nameOverride: ""
 fullnameOverride: ""
 
 controlThePayloadConfig: ""
 secret:
-  annotations: {}
+  annotations: { }
   name: ""
   useExistingSecret: false
 
@@ -27,19 +27,21 @@ env:
     PORT_CLIENT_ID: ""
     PORT_CLIENT_SECRET: ""
 
-podAnnotations: {}
+extraLabels: { }
 
-podSecurityContext: {}
-# Example 
+podAnnotations: { }
+
+podSecurityContext: { }
+  # Example
   # runAsGroup: 1001
   # runAsUser: 1001
   # fsGroup: 1001
-  # fsGroupChangePolicy: "OnRootMismatch"
-containerSecurityContext: {}
-# Example 
+# fsGroupChangePolicy: "OnRootMismatch"
+containerSecurityContext: { }
+  # Example
   # runAsGroup: 1001
   # runAsUser: 1001
-  # allowPrivilegeEscalation: false
+# allowPrivilegeEscalation: false
 
 rolloutStrategy: "Recreate"
 
@@ -51,11 +53,11 @@ resources:
     memory: "256Mi"
     cpu: "200m"
 
-nodeSelector: {}
+nodeSelector: { }
 
-tolerations: []
+tolerations: [ ]
 
-affinity: {}
+affinity: { }
 
 selfSignedCertificate:
   enabled: false

--- a/charts/port-ocean/templates/_helpers.tpl
+++ b/charts/port-ocean/templates/_helpers.tpl
@@ -40,6 +40,9 @@ helm.sh/chart: {{ include "port-ocean.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- range $key, $value := .Values.extraLabels }}
+{{$key}}: {{ $value }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/port-ocean/templates/deployment.yaml
+++ b/charts/port-ocean/templates/deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "port-ocean.deploymentName" . }}
+  labels:
+    {{- include "port-ocean.labels" . | nindent 8 }}
 spec:
   strategy:
     type: {{ .Values.rolloutStrategy | default "Recreate" }}
@@ -9,10 +11,12 @@ spec:
   selector:
     matchLabels:
       app: {{ include "port-ocean.deploymentName" . }}
+      {{- include "port-ocean.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
         app: {{ include "port-ocean.deploymentName" .}}
+        {{- include "port-ocean.labels" . | nindent 8 }}
     spec:
       securityContext: 
         {{- if .Values.podSecurityContext }}

--- a/charts/port-ocean/values.yaml
+++ b/charts/port-ocean/values.yaml
@@ -6,28 +6,28 @@ port:
   clientSecret: ""
   baseUrl: https://api.getport.io
 
-podAnnotations: {}
+podAnnotations: { }
 
 extraEnv:
 # Example
 #   - name: HTTPS_PROXY
 #     value: http://myproxy.com
 
-podSecurityContext: {}
-# Example 
+podSecurityContext: { }
+  # Example
   # runAsGroup: 1001
   # runAsUser: 1001
   # fsGroup: 1001
-  # fsGroupChangePolicy: "OnRootMismatch"
-containerSecurityContext: {}
-# Example 
+# fsGroupChangePolicy: "OnRootMismatch"
+containerSecurityContext: { }
+  # Example
   # runAsGroup: 1001
   # runAsUser: 1001
-  # allowPrivilegeEscalation: false
+# allowPrivilegeEscalation: false
 
 rolloutStrategy: "Recreate"
 
-resources: 
+resources:
   requests:
     memory: "512Mi"
     cpu: "200m"
@@ -36,11 +36,13 @@ resources:
     cpu: "500m"
 
 
-nodeSelector: {}
+nodeSelector: { }
 
-tolerations: []
+tolerations: [ ]
 
-affinity: {}
+affinity: { }
+
+extraLabels: { }
 
 imageRegistry: "ghcr.io/port-labs"
 
@@ -60,27 +62,27 @@ service:
   enabled: true
   type: ClusterIP
   port: 8000
-  annotations: {}
-  
+  annotations: { }
+
 ingress:
   enabled: false
   className: ""
-  annotations: {}
+  annotations: { }
   host: null
   path: /
   pathType: Prefix
-  tls: []
+  tls: [ ]
   # Example
   #   - secretName: my-secret
   #     hosts:
   #       - "my-host.my-domain.com"
-  
+
 integration:
   identifier: ""
   version: ""
   type: ""
-  config: {}
-  secrets: {}
+  config: { }
+  secrets: { }
   eventListener:
     type: "KAFKA"
     brokers: "b-1-public.publicclusterprod.t9rw6w.c1.kafka.eu-west-1.amazonaws.com:9196,b-2-public.publicclusterprod.t9rw6w.c1.kafka.eu-west-1.amazonaws.com:9196,b-3-public.publicclusterprod.t9rw6w.c1.kafka.eu-west-1.amazonaws.com:9196"


### PR DESCRIPTION
# Description

What - Allowing attaching extra labels to ocean & port-agent deployments
How - Using the extraLabels key now

## Type of change

- [X] New feature (non-breaking change which adds functionality)

