### PR TITLE
chore: Add pod annotations to port-ocean deployment

### DIFF
--- a/charts/port-ocean/Chart.yaml
+++ b/charts/port-ocean/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-ocean
 description: A Helm chart for Port Ocean integrations
 type: application
-version: 0.1.23
+version: 0.1.24
 appVersion: "0.1.0"
 home: https://getport.io/
 sources:

--- a/charts/port-ocean/templates/deployment.yaml
+++ b/charts/port-ocean/templates/deployment.yaml
@@ -14,6 +14,10 @@ spec:
       {{- include "port-ocean.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app: {{ include "port-ocean.deploymentName" .}}
         {{- include "port-ocean.labels" . | nindent 8 }}


### PR DESCRIPTION
# Description

What - `podAnnotations` is missing in deployment.yaml
Why - `podAnnotations` is defined value.yaml, but not applied to deployment.yaml.
How - Add `podAnnotations` to deployment.yaml

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

