### PR TITLE
fix: provision REQUESTS_CA_BUNDLE env for self-signed certificate

### DIFF
--- a/charts/port-ocean/templates/deployment.yaml
+++ b/charts/port-ocean/templates/deployment.yaml
@@ -56,6 +56,8 @@ spec:
         {{- if .Values.selfSignedCertificate.enabled }}
           - name: SSL_CERT_FILE
             value: /etc/ssl/certs/ca-certificates.crt
+          - name: REQUESTS_CA_BUNDLE
+            value: /etc/ssl/certs/ca-certificates.crt
         {{- end }}
         {{- with .Values.extraEnv }}
           {{- toYaml . | nindent 10 }}


### PR DESCRIPTION
# Description

**What** - provision `REQUESTS_CA_BUNDLE` environment variable to make the Gitlab integration properly work with self-hosted instances with self-signed certificates
**Why** - the current implementation relies on the `requests` library to fetch Gitlab resources, which in turn requires the `REQUESTS_CA_BUNDLE` variable to be set to the certificate file to properly use custom certificates on HTTP requests. 

Reference: https://python-gitlab.readthedocs.io/en/stable/api-usage-advanced.html#ssl-certificate-verification

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

