### PR TITLE
secret name override

### DIFF
--- a/charts/port-ocean/Chart.yaml
+++ b/charts/port-ocean/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-ocean
 description: A Helm chart for Port Ocean integrations
 type: application
-version: 0.4.0
+version: 0.4.1
 appVersion: "0.1.0"
 home: https://getport.io/
 sources:

--- a/charts/port-ocean/templates/_helpers.tpl
+++ b/charts/port-ocean/templates/_helpers.tpl
@@ -126,7 +126,7 @@ Get self signed cert secret name
 
 {{- define "port-ocean.additionalSecrets" }}
 {{- $secretsArray := list }}
-{{- if .Values.secret.create }}
+{{- if or .Values.secret.create .Values.secret.name }}
   {{- $secretsArray = list (include "port-ocean.secretName" .) }}
 {{- end }}
 {{- /* If the secretName is already an array we don't wrap it in an array */}}


### PR DESCRIPTION
# Description

What - When overriding the secret name without asking the chart to create it for you it will ignore the secret
Why - Logic issue

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
