### PR TITLE
fix(ocean): Shorten the name of the cron jobs

### DIFF
--- a/charts/port-ocean/Chart.yaml
+++ b/charts/port-ocean/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-ocean
 description: A Helm chart for Port Ocean integrations
 type: application
-version: 0.4.1
+version: 0.4.2
 appVersion: "0.1.0"
 home: https://getport.io/
 sources:

--- a/charts/port-ocean/templates/_helpers.tpl
+++ b/charts/port-ocean/templates/_helpers.tpl
@@ -60,6 +60,10 @@ Get prefix of ocean resource metadata.name
 {{- printf "ocean-%s-%s" .Values.integration.type .Values.integration.identifier }}
 {{- end }}
 
+{{- define "port-ocean.metadataNamePrefixShort" -}}
+{{- printf "%s-%s" .Values.integration.type .Values.integration.identifier }}
+{{- end }}
+
 {{/*
 Get config map name 
 */}}

--- a/charts/port-ocean/templates/cron-job/cron.yaml
+++ b/charts/port-ocean/templates/cron-job/cron.yaml
@@ -17,7 +17,7 @@ spec:
   concurrencyPolicy: Replace
   jobTemplate:
     metadata:
-      generateName: {{ include "port-ocean.cronJobName" . }}-
+      generateName: {{ include "port-ocean.metadataNamePrefixShort" . }}-
       namespace: {{ .Release.Namespace }}
       labels:
         app: {{ include "port-ocean.cronJobName" . }}

--- a/charts/port-ocean/templates/cron-job/installation-resync-job.yml
+++ b/charts/port-ocean/templates/cron-job/installation-resync-job.yml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     helm.sh/hook: post-install, post-upgrade
     helm.sh/hook-delete-policy: hook-succeeded, hook-failed
-  name: {{ include "port-ocean.cronJobName" . }}-init-resync-{{ .Release.Name }}-{{ $jobName }}
+  name: init-sync-{{ .Release.Name }}-{{ $jobName }}
 spec:
   ttlSecondsAfterFinished: 600
   activeDeadlineSeconds: 30
@@ -27,6 +27,6 @@ spec:
                   name: {{ include "port-ocean.cron.job-query-rbac-prefix" . }}-sa-token
                   key: token
           args:
-            - kubectl create job --from=cronjob/{{ include "port-ocean.cronJobName" . }} init-resync-{{ .Release.Name }}-{{ $jobName }} --token=$TOKEN
+            - kubectl create job --from=cronjob/{{ include "port-ocean.cronJobName" . }} init-sync-{{ $jobName }} --token=$TOKEN
       restartPolicy: Never
 {{- end }}


### PR DESCRIPTION
# Description

What - Cron jobs failed to start due to a very long job name for the init job

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
