### PR TITLE
More active deadline for init sync job

### DIFF
--- a/charts/port-ocean/Chart.yaml
+++ b/charts/port-ocean/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-ocean
 description: A Helm chart for Port Ocean integrations
 type: application
-version: 0.5.1
+version: 0.5.2
 appVersion: "0.1.0"
 home: https://getport.io/
 sources:

--- a/charts/port-ocean/templates/cron-job/installation-resync-job.yml
+++ b/charts/port-ocean/templates/cron-job/installation-resync-job.yml
@@ -11,11 +11,11 @@ metadata:
   name: init-sync-{{ .Release.Name }}-{{ $jobName }}
 spec:
   ttlSecondsAfterFinished: 600
-  activeDeadlineSeconds: 30
+  activeDeadlineSeconds: 180
   backoffLimit: 0
   template:
     spec:
-      activeDeadlineSeconds: 30
+      activeDeadlineSeconds: 180
       containers:
         - name: kubectl
           image: bitnami/kubectl:latest


### PR DESCRIPTION
# Description

What - Job is dying before starting in karpenter
Why - Sometime when using karpenter there is a need for more time before killing the init sync job
How - more deadline time

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

