### PR TITLE
Removed self certificate dedicated command

### DIFF
--- a/charts/port-agent/Chart.yaml
+++ b/charts/port-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: port-agent
 description: A Helm chart for Port Agent
 type: application
-version: 0.8.3
-appVersion: "v0.7.6"
+version: 0.8.4
+appVersion: "v0.7.7"
 home: https://getport.io/
 sources:
   - https://github.com/port-labs/port-agent

--- a/charts/port-agent/templates/deployment.yaml
+++ b/charts/port-agent/templates/deployment.yaml
@@ -35,9 +35,6 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.selfSignedCertificate.enabled }}
-          command: [ "sh", "-c", "update-ca-certificates && python3 main.py" ]
-          {{- end }}
           securityContext:
           {{- if .Values.containerSecurityContext }}
             {{- toYaml .Values.containerSecurityContext | nindent 14 }}


### PR DESCRIPTION

# Description

What - removed self certificate dedicated command
Why - it not using python's venv with it's dependencies

## Type of change

Please leave one option from the following and delete the rest:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

