### PR TITLE
add terminationGracePeriodSeconds to port-ocean deployment spec

### DIFF
--- a/charts/port-ocean/templates/deployment.yaml
+++ b/charts/port-ocean/templates/deployment.yaml
@@ -80,6 +80,7 @@ spec:
             readOnly: true
         {{- end }}
         {{- if (.Values.livenessProbe).enabled}}
+        terminationGracePeriodSeconds: {{ default 30 .Values.terminationGracePeriodSeconds }}
         livenessProbe:
           httpGet:
             path: /docs


### PR DESCRIPTION
# Description
add terminationGracePeriodSeconds to port-ocean deployment spec

What - Add the option for setting the terminationGracePeriodSeconds attr in the port-ocean chart 
Why - 
How -

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

