### PR TITLE
Add terminationGracePeriodSeconds attr to port-ocean chart

### DIFF
--- a/charts/port-ocean/Chart.yaml
+++ b/charts/port-ocean/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-ocean
 description: A Helm chart for Port Ocean integrations
 type: application
-version: 0.5.2
+version: 0.5.3
 appVersion: "0.1.0"
 home: https://getport.io/
 sources:

--- a/charts/port-ocean/templates/deployment.yaml
+++ b/charts/port-ocean/templates/deployment.yaml
@@ -26,6 +26,7 @@ spec:
       {{- with .Values.podServiceAccount.name }}
       serviceAccountName: {{ . }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ default 30 .Values.terminationGracePeriodSeconds }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/port-ocean/values.yaml
+++ b/charts/port-ocean/values.yaml
@@ -79,6 +79,7 @@ scheduledResyncInterval: null
 #  scheduledResyncInterval: 60 # minutes - Used for Deployment workload.kind
 #  scheduledResyncInterval: "*/60 * * * *" # cron expression - Used for CronJob workload.kind
 
+terminationGracePeriodSeconds: 30
 
 clientTimeout: null
 


### PR DESCRIPTION
# Description
Add terminationGracePeriodSeconds attr to port-ocean chart

What - Add the option for setting terminationGracePeriodSeconds value in the port-ocean chart
Why -  
How -

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

