### PR TITLE
fix: live events service defaults false

### DIFF
--- a/charts/port-ocean/Chart.yaml
+++ b/charts/port-ocean/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-ocean
 description: A Helm chart for Port Ocean integrations
 type: application
-version: 0.6.0
+version: 0.6.1
 appVersion: "0.1.0"
 home: https://getport.io/
 sources:

--- a/charts/port-ocean/values.yaml
+++ b/charts/port-ocean/values.yaml
@@ -143,7 +143,7 @@ liveEvents:
         memory: "1024Mi"
         cpu: "500m"
   service:
-    enabled: true
+    enabled: false
     type: ClusterIP
     port: 8000
     annotations: {}


### PR DESCRIPTION
# Description

What - Fixed default value for live events service to be disabled
Why - Only necessary for when live events standalone worker is enabled
How -

## Type of change

Please leave one option from the following and delete the rest:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

