### PR TITLE
Fix issue with port-ocean and using existing secrets

### DIFF
--- a/charts/port-ocean/templates/_helpers.tpl
+++ b/charts/port-ocean/templates/_helpers.tpl
@@ -171,7 +171,7 @@ Get self signed cert secret name
 
 {{- define "port-ocean.additionalSecrets" }}
 {{- $secretsArray := list }}
-{{- if or .Values.secret.create .Values.secret.name }}
+{{- if or .Values.secret.create .Values.secret.name .Values.secret.useExistingSecret }}
   {{- $secretsArray = list (include "port-ocean.secretName" .) }}
 {{- end }}
 {{- /* If the secretName is already an array we don't wrap it in an array */}}


### PR DESCRIPTION
# Description
The helm chart was not respecting the `secret.useExistingSecret` option and was generating YAML for `Deployment` resources that were not referencing the secrets.  This was causing a crashLoopBackoff b/c the applications expect the secrets to be present.

## Type of change
The helper that creates this YAML snippet has been updated to consider the `secret.useExistingSecret` value when conditionally making its snippet.

- [x] Bug fix (non-breaking change which fixes an issue)

---

  * Closes #29
  * Closes #131