### PR TITLE
Added new scheduleConcurrencyPolicy variable for Ocean

### DIFF
--- a/charts/port-ocean/templates/cron-job/cron.yaml
+++ b/charts/port-ocean/templates/cron-job/cron.yaml
@@ -15,7 +15,7 @@ spec:
   successfulJobsHistoryLimit: 1
   schedule: {{ .Values.scheduledResyncInterval | default "0 */1 * * *" }}
   suspend: {{ or .Values.workload.cron.suspend (eq .Values.scheduledResyncInterval "")}}
-  concurrencyPolicy: Replace
+  concurrencyPolicy: {{ .Values.scheduleConcurrencyPolicy | default "Replace" }}
   jobTemplate:
     metadata:
       generateName: {{ include "port-ocean.metadataNamePrefixShort" . }}-

--- a/charts/port-ocean/values.yaml
+++ b/charts/port-ocean/values.yaml
@@ -79,6 +79,8 @@ scheduledResyncInterval: null
 #  scheduledResyncInterval: 60 # minutes - Used for Deployment workload.kind
 #  scheduledResyncInterval: "*/60 * * * *" # cron expression - Used for CronJob workload.kind
 
+scheduleConcurrencyPolicy: "Replace"
+
 terminationGracePeriodSeconds: 30
 
 clientTimeout: null


### PR DESCRIPTION
Update cron job concurrency policy to use configurable value in values.yaml

# Description

What - Added the scheduleConcurrencyPolicy variable to values.yaml
Why - Being able to configure how the cronjob behaves
How - Added it as configurable var

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

