### PR TITLE
Allow metadata name prefix override

### DIFF
--- a/charts/port-ocean/Chart.yaml
+++ b/charts/port-ocean/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-ocean
 description: A Helm chart for Port Ocean integrations
 type: application
-version: 0.7.2
+version: 0.7.3
 appVersion: "0.1.0"
 home: https://getport.io/
 sources:

--- a/charts/port-ocean/templates/_helpers.tpl
+++ b/charts/port-ocean/templates/_helpers.tpl
@@ -78,11 +78,19 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Get prefix of ocean resource metadata.name
 */}}
 {{- define "port-ocean.metadataNamePrefix" -}}
+{{- if .Values.metadataNamePrefixOverride }}
+{{- printf "%s" .Values.metadataNamePrefixOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
 {{- printf "ocean-%s-%s" .Values.integration.type .Values.integration.identifier | trunc 63 | trimSuffix "-" }}
+{{- end }}
 {{- end }}
 
 {{- define "port-ocean.metadataNamePrefixShort" -}}
+{{- if .Values.metadataNamePrefixOverride }}
+{{- printf "%s" .Values.metadataNamePrefixOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
 {{- printf "%s-%s" .Values.integration.type .Values.integration.identifier | trunc 63 | trimSuffix "-" }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/port-ocean/values.yaml
+++ b/charts/port-ocean/values.yaml
@@ -1,5 +1,6 @@
 nameOverride: ""
 fullnameOverride: ""
+metadataNamePrefixOverride: ""
 
 port:
   clientId: ""


### PR DESCRIPTION
# Description

What - Conflict on same integration name on the same cluster for different tenants in port
Why - Metadata prefix for k8s resources is crafted based on integration identifier and resource type, so for the same name of integration on a different tenant but deploy in the same cluster, it conflicted as resources with same name existed already
How - Add a property in the helpers template to override specifically the metadata name prefix, avoiding breaking changes.

## Type of change

- New feature (non-breaking change which adds functionality)

