### PR TITLE
added to support array in integration config

### DIFF
--- a/charts/port-ocean/templates/configmap.yaml
+++ b/charts/port-ocean/templates/configmap.yaml
@@ -32,7 +32,7 @@ data:
   {{- end }}
   {{- if .Values.integration.config }}
   {{- range $key, $value := .Values.integration.config }}
-  OCEAN__INTEGRATION__CONFIG__{{ $key | snakecase | upper }}: {{ $value | quote }}
+  OCEAN__INTEGRATION__CONFIG__{{ $key | snakecase | upper }}:{{- if kindIs "slice" $value }} {{ $value | toJson }}{{ else }} {{ $value | quote }}{{ end }}
   {{- end }}
   {{- end }}
   {{- if .Values.integration.extraConfig }}


### PR DESCRIPTION
# Description

What - Added support in helm chart to support, array in integration config.
Why - It is needed, if someone wants to pass array in integration config. We just had quote there which was converting array in to unexpected format.
How - using toJson only for arrays, and quote for everything else
## Type of change

Please leave one option from the following and delete the rest:
- [X] New feature (non-breaking change which adds functionality)
