### PR TITLE
httpLoggingEnabled bool as string in values.yaml

### DIFF
--- a/charts/port-k8s-exporter/values.yaml
+++ b/charts/port-k8s-exporter/values.yaml
@@ -29,7 +29,7 @@ eventListener:
   securityProtocol: "SASL_SSL"
   authenticationMechanism: "SCRAM-SHA-512"
 
-httpLoggingEnabled: true
+httpLoggingEnabled: "true"
 loggingLevel: "info"
 secret:
   annotations: {}


### PR DESCRIPTION
# Description

Applying the helm chart created this error for me: 
```
Error: 1 error occurred:
	* Deployment in version "v1" cannot be handled as a Deployment: json: cannot unmarshal bool into Go struct field EnvVar.spec.template.spec.containers.env.value of type string
```

I templated the helm chart locally and applied the deployment spec manually
```
helm template port-labs/port-k8s-exporter \
        --set secret.secrets.portClientId="xxxx"  \
        --set secret.secrets.portClientSecret="xxx"  \
        --set portBaseUrl="https://api.port.io"  \
        --set stateKey="k8s-my-cluster"  \
        --set eventListener.type="POLLING"  \
        --set "extraEnv[0].name"="CLUSTER_NAME"  \
        --set "extraEnv[0].value"="k8s-my-cluster" 
```
Which lead me to determining it was this line: 
```
            - name: HTTP_LOGGING_ENABLED
              value: true
```

Changing this line to a string allowed me to apply and the chart works properly
```
            - name: HTTP_LOGGING_ENABLED
              value: "true"
```

For what it's worth, I am running an older version of Kubernetes - 1.28.

## Type of change

Please leave one option from the following and delete the rest:

- [X] Bug fix (non-breaking change which fixes an issue)

