### PR TITLE
(feat) Introduce LAKEHOUSE_ENABLED and INGEST_URL configuration values

### DIFF
--- a/charts/port-ocean/Chart.yaml
+++ b/charts/port-ocean/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-ocean
 description: A Helm chart for Port Ocean integrations
 type: application
-version: 0.9.5
+version: 0.9.6
 appVersion: "0.1.0"
 home: https://getport.io/
 sources:

--- a/charts/port-ocean/templates/configmap-live-events.yaml
+++ b/charts/port-ocean/templates/configmap-live-events.yaml
@@ -5,6 +5,7 @@ metadata:
   name: "{{ include "port-ocean.liveEvents.configMapName" . }}"
 data:
   OCEAN__PORT__BASE_URL: {{ .Values.port.baseUrl | quote }}
+  OCEAN__PORT__INGEST_URL: {{ .Values.port.ingestUrl | quote }}
   # Make sure only sync pods will initialize resources if both are enabled
   {{- if eq .Values.initializePortResources true}}
   OCEAN__INITIALIZE_PORT_RESOURCES: "false"

--- a/charts/port-ocean/templates/configmap.yaml
+++ b/charts/port-ocean/templates/configmap.yaml
@@ -8,6 +8,7 @@ metadata:
   name: {{ include "port-ocean.configMapName" . }}
 data:
   OCEAN__PORT__BASE_URL: {{ .Values.port.baseUrl | quote }}
+  OCEAN__PORT__INGEST_URL: {{ .Values.port.ingestUrl | quote }}
   OCEAN__INITIALIZE_PORT_RESOURCES: "{{ .Values.initializePortResources | default false }}"
   OCEAN__ALLOW_ENVIRONMENT_VARIABLES_JQ_ACCESS: "{{ .Values.allowEnvironmentVariablesJqAccess | default true }}"
   {{- if  and .Values.scheduledResyncInterval (not (eq .Values.workload.kind "CronJob")) }}

--- a/charts/port-ocean/templates/configmap.yaml
+++ b/charts/port-ocean/templates/configmap.yaml
@@ -40,3 +40,4 @@ data:
   {{ $key | snakecase | upper }}: {{ $value | quote }}
   {{- end }}
   {{- end }}
+  OCEAN__DATALAKE_ENABLED: "{{ .Values.datalakeEnabled | default false }}"

--- a/charts/port-ocean/templates/configmap.yaml
+++ b/charts/port-ocean/templates/configmap.yaml
@@ -40,4 +40,4 @@ data:
   {{ $key | snakecase | upper }}: {{ $value | quote }}
   {{- end }}
   {{- end }}
-  OCEAN__DATALAKE_ENABLED: "{{ .Values.datalakeEnabled | default false }}"
+  OCEAN__LAKEHOUSE_ENABLED: "{{ .Values.lakehouseEnabled | default false }}"

--- a/charts/port-ocean/values.yaml
+++ b/charts/port-ocean/values.yaml
@@ -205,3 +205,5 @@ postgresql:
         password: password
         postgresPassword: password
         username: port_admin
+
+datalakeEnabled: false

--- a/charts/port-ocean/values.yaml
+++ b/charts/port-ocean/values.yaml
@@ -206,4 +206,4 @@ postgresql:
         postgresPassword: password
         username: port_admin
 
-datalakeEnabled: false
+lakehouseEnabled: false

--- a/charts/port-ocean/values.yaml
+++ b/charts/port-ocean/values.yaml
@@ -7,6 +7,7 @@ port:
   clientSecret: ""
 
   baseUrl: https://api.getport.io
+  ingestUrl: https://ingest.getport.io
 
 podAnnotations: { }
 


### PR DESCRIPTION
# Description

What - added new OCEAN__LAKEHOUSE_ENABLED config value
Why - we want to allow control per integration to send data to the lake
How - if the configuration value is set to `true` the data will be sent

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

