### PR TITLE
[k8s-exporter] Fixed http param value as a configuration

### DIFF
--- a/charts/port-k8s-exporter/Chart.yaml
+++ b/charts/port-k8s-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-k8s-exporter
 description: A Helm chart for Port Kubernetes Exporter
 type: application
-version: 0.3.8
+version: 0.3.9
 appVersion: "0.5.11"
 home: https://getport.io/
 sources:

--- a/charts/port-k8s-exporter/templates/deployment.yaml
+++ b/charts/port-k8s-exporter/templates/deployment.yaml
@@ -59,7 +59,7 @@ spec:
             - name: EVENT_LISTENER_TYPE
               value: {{ .Values.eventListener.type }}
             - name: HTTP_LOGGING_ENABLED
-              value: {{ .Values.httpLoggingEnabled }}
+              value: {{ .Values.httpLoggingEnabled | quote }}
             - name: LOGGING_LEVEL
               value: {{ .Values.loggingLevel | quote }}
             {{- if eq .Values.eventListener.type "POLLING" }}


### PR DESCRIPTION
# Description

Fixed bug where the `HTTP_LOGGING_ENABLED` was treated as a bool when needs to be passed as a string configuration

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

