### PR TITLE
toggle base_url to avoid have this for both workload and liveevents

### DIFF
--- a/charts/port-ocean/Chart.yaml
+++ b/charts/port-ocean/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-ocean
 description: A Helm chart for Port Ocean integrations
 type: application
-version: 0.9.10-dev-0.1.0
+version: 0.9.11-dev-0.1.0
 appVersion: "0.1.0"
 home: https://getport.io/
 sources:

--- a/charts/port-ocean/templates/deployment.yaml
+++ b/charts/port-ocean/templates/deployment.yaml
@@ -88,7 +88,7 @@ spec:
           - name: OCEAN__DATABASE__PASSWORD
             value: {{ .Values.postgresql.global.postgresql.auth.password }}
         {{- end }}
-        {{- if .Values.liveEvents.baseUrl }}
+        {{- if and .Values.liveEvents.baseUrl .Values.liveEvents.worker.enabled }}
           - name: OCEAN__BASE_URL
             value: {{ .Values.liveEvents.baseUrl }}
         {{- end }}

--- a/charts/port-ocean/values.yaml
+++ b/charts/port-ocean/values.yaml
@@ -45,6 +45,7 @@ workload:
   deployment:
     rolloutStrategy: "Recreate"
     replicas: 1 # Currently only allows 1 or 0 replicas
+    webhooksEnabled: true
 
   cron:
     # number of minutes to wait before cancelling the resync


### PR DESCRIPTION
# Description

What - Having this for certain integrations, like bitbucket, enable webhook functionality for both sync workload and liveEvents at the same time.
Why - To avoid have enable same behaviour than the liveEvents deployment if we do have both. Increases performance on bulk operation, and avoid target integration to reduce the amount of API calls.
How - With new toggle configuration to opt-out on demand. By default is true to ensure backwards compatibility.

## Type of change

Please leave one option from the following and delete the rest:

- [ X] New feature (non-breaking change which adds functionality)
