### PR TITLE
[Ocean] Added defaults to client id and secret

### DIFF
--- a/charts/port-ocean/Chart.yaml
+++ b/charts/port-ocean/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-ocean
 description: A Helm chart for Port Ocean integrations
 type: application
-version: 0.15.8
+version: 0.15.9
 appVersion: "0.1.0"
 home: https://getport.io/
 sources:

--- a/charts/port-ocean/values.yaml
+++ b/charts/port-ocean/values.yaml
@@ -3,8 +3,8 @@ fullnameOverride: ""
 metadataNamePrefixOverride: ""
 
 port:
-  clientId: ""
-  clientSecret: ""
+  clientId: "<enter your client id here>"
+  clientSecret: "<enter your client secret here>"
 
   baseUrl: https://api.getport.io
   ingestUrl: https://ingest.getport.io


### PR DESCRIPTION
# Description

What - Added defaults to port's client id and secret
Why - allowing to run `helm template test charts/port-ocean` without being blocked by client id and secret
How - Adding default values to the `values.yaml` file

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

