### PR TITLE
[Ocean] Added default values for integration identifier and type

### DIFF
--- a/charts/port-ocean/Chart.yaml
+++ b/charts/port-ocean/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-ocean
 description: A Helm chart for Port Ocean integrations
 type: application
-version: 0.15.9
+version: 0.15.10
 appVersion: "0.1.0"
 home: https://getport.io/
 sources:

--- a/charts/port-ocean/templates/_helpers.tpl
+++ b/charts/port-ocean/templates/_helpers.tpl
@@ -231,7 +231,7 @@ Enforces Kubernetes CronJob name limit of 52 characters
 {{- $prefix := include "port-ocean.metadataNamePrefix" . -}}
 {{- $cronJobName := printf "%s-cron-job" $prefix -}}
 {{- if gt (len $cronJobName) 52 -}}
-{{- $maxPrefixLen := sub 52 9 -}}
+{{- $maxPrefixLen := int (sub 52 9) -}}
 {{- $truncatedPrefix := trunc $maxPrefixLen $prefix | trimSuffix "-" -}}
 {{- printf "%s-cron-job" $truncatedPrefix -}}
 {{- else -}}

--- a/charts/port-ocean/values.yaml
+++ b/charts/port-ocean/values.yaml
@@ -145,9 +145,9 @@ ingress:
   #       - "my-host.my-domain.com"
 
 integration:
-  identifier: ""
+  identifier: "default-identifier"
   version: ""
-  type: ""
+  type: "default-type"
   config: { }
   secrets: { }
   extraConfig: { }


### PR DESCRIPTION
# Description

What - Added default values for integration identifier and type
Why - Allowing running the `helm template test charts/port-ocean`
How - Added defaults to the `values.yaml`

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

