### PR TITLE
Fix: OAuth path don't align with ocean Dockerfile

### DIFF
--- a/charts/port-ocean/values.yaml
+++ b/charts/port-ocean/values.yaml
@@ -156,7 +156,7 @@ integration:
     prometheusMultiProcessDir: "/tmp/ocean/prometheus/metrics"
   oauth:
     enabled: false
-    access_token_file_path: "/app/.config/oauth_token"
+    access_token_file_path: "/tmp/ocean/.config/oauth_token"
   eventListener:
     type: "KAFKA"
     brokers: "b-1-public.publicclusterprod.t9rw6w.c1.kafka.eu-west-1.amazonaws.com:9196,b-2-public.publicclusterprod.t9rw6w.c1.kafka.eu-west-1.amazonaws.com:9196,b-3-public.publicclusterprod.t9rw6w.c1.kafka.eu-west-1.amazonaws.com:9196"


### PR DESCRIPTION
# Description
due to change in ocean docker file [here](https://github.com/port-labs/ocean/commit/3ca12c6435d8186f4d21acc7aa87422c61f8ea18#diff-b1c90b5a5de591768958e6775a7392c2f6880a6c72ecbf751f3bfbdf7ec2746c)
integrations access wrong oauth file path.

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

