### PR TITLE
chore(port-agent): bump chart version to 0.8.13 and update app version to 0.8.8

### DIFF
--- a/charts/port-agent/Chart.yaml
+++ b/charts/port-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: port-agent
 description: A Helm chart for Port Agent
 type: application
-version: 0.8.12
-appVersion: "v0.8.7"
+version: 0.8.13
+appVersion: "v0.8.8"
 home: https://getport.io/
 sources:
   - https://github.com/port-labs/port-agent

--- a/charts/port-agent/README.md
+++ b/charts/port-agent/README.md
@@ -118,7 +118,7 @@ For environments requiring multiple custom certificates, you can use the `extraV
 
 ## Streamer Types
 
-The Port Agent supports two streamer mechanisms for receiving action runs:
+The Port Agent supports two streamer mechanisms for receiving action runs and workflow node runs:
 
 ### Kafka Streamer (Default)
 
@@ -139,17 +139,18 @@ helm upgrade --install my-port-agent port-labs/port-agent \
 
 ### POLLING Streamer
 
-An alternative streamer mechanism that uses HTTP polling to retrieve action runs from the Port API.
+An alternative streamer mechanism that uses HTTP polling to retrieve action runs and workflow node runs from the Port API.
 
 **Advantages:**
 - Works in environments with Kafka connectivity restrictions
 - Simpler network requirements (HTTP only)
 - No Kafka consumer group management needed
+- Supports action runs and workflow node runs
 
 **Considerations:**
 - Polling-based, not real-time
 - Higher latency compared to Kafka
-- Only supports action runs (not changelog destinations)
+- Does not support changelog destinations
 
 **Configuration:**
 ```bash


### PR DESCRIPTION
# Description

What - Bump chart version to 0.8.13 and update app version to 0.8.8; enhance README to clarify streamer mechanisms
Why - New port-agent to fix an issue with triggering workflow nodes runs via kafka streamer
How - Use unified kafka topic for action runs and workflow node runs.

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

