### PR TITLE
chore(port-ocean): bump chart version to 0.18.0

### DIFF
--- a/charts/port-ocean/Chart.yaml
+++ b/charts/port-ocean/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-ocean
 description: A Helm chart for Port Ocean integrations
 type: application
-version: 0.17.0
+version: 0.18.0
 appVersion: "0.1.0"
 home: https://getport.io/
 sources:


### PR DESCRIPTION
## Summary
- Bump `port-ocean` chart version from 0.17.0 to 0.18.0
- Publishes the changes from #286 that remove `OCEAN__PORT__INGEST_URL` from ConfigMap templates, allowing Ocean core to derive the correct ingest URL per region (especially US accounts)

## Test plan
- [ ] CI publishes `port-ocean-0.18.0.tgz` to GitHub releases / helm index
- [ ] Confirm new version appears at https://port-labs.github.io/helm-charts/index.yaml
- [ ] Merge before port-labs/infra-apps companion PR (depends on this chart being published)


Made with [Cursor](https://cursor.com)