### PR TITLE
Block/warn on chart changes without version bump

### DIFF
--- a/.github/scripts/check-version-bump.sh
+++ b/.github/scripts/check-version-bump.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Determine the base branch - use GITHUB_BASE_REF for PRs, otherwise use main
+BASE_BRANCH="${GITHUB_BASE_REF:-main}"
+echo "Checking for chart changes against base branch: origin/${BASE_BRANCH}"
+
+# Get list of changed files
+CHANGED_FILES=$(git diff --name-only origin/${BASE_BRANCH}...HEAD)
+
+if [ -z "$CHANGED_FILES" ]; then
+  echo -e "${GREEN}✓ No changes detected${NC}"
+  exit 0
+fi
+
+echo "Changed files:"
+echo "$CHANGED_FILES"
+echo ""
+
+# Track if we found any violations
+VIOLATIONS_FOUND=0
+
+# Get list of all chart directories
+CHART_DIRS=$(find charts -mindepth 1 -maxdepth 1 -type d)
+
+for CHART_DIR in $CHART_DIRS; do
+  CHART_NAME=$(basename "$CHART_DIR")
+  CHART_YAML="${CHART_DIR}/Chart.yaml"
+
+  if [ ! -f "$CHART_YAML" ]; then
+    echo -e "${YELLOW}⚠ Skipping ${CHART_DIR} - no Chart.yaml found${NC}"
+    continue
+  fi
+
+  # Check if any files in this chart directory changed (excluding Chart.yaml and Chart.lock)
+  CONTENT_CHANGES=$(echo "$CHANGED_FILES" | grep "^${CHART_DIR}/" | grep -v "Chart.yaml$" | grep -v "Chart.lock$" || true)
+
+  if [ -z "$CONTENT_CHANGES" ]; then
+    echo -e "${GREEN}✓ ${CHART_NAME}: No content changes${NC}"
+    continue
+  fi
+
+  # Content was changed, now check if version was bumped
+  echo -e "\n${YELLOW}Checking ${CHART_NAME} - content files changed:${NC}"
+  echo "$CONTENT_CHANGES" | sed 's/^/  /'
+
+  # Get current version
+  CURRENT_VERSION=$(grep "^version:" "$CHART_YAML" | awk '{print $2}')
+
+  # Get previous version from base branch
+  PREVIOUS_VERSION=$(git show origin/${BASE_BRANCH}:${CHART_YAML} 2>/dev/null | grep "^version:" | awk '{print $2}' || echo "")
+
+  if [ -z "$PREVIOUS_VERSION" ]; then
+    echo -e "${GREEN}✓ ${CHART_NAME}: New chart (version: ${CURRENT_VERSION})${NC}"
+    continue
+  fi
+
+  echo "  Current version:  ${CURRENT_VERSION}"
+  echo "  Previous version: ${PREVIOUS_VERSION}"
+
+  if [ "$CURRENT_VERSION" = "$PREVIOUS_VERSION" ]; then
+    echo -e "${RED}✗ ${CHART_NAME}: Chart content changed but version was not bumped!${NC}"
+    echo -e "${RED}  Please update the version in ${CHART_YAML}${NC}"
+    VIOLATIONS_FOUND=1
+  else
+    echo -e "${GREEN}✓ ${CHART_NAME}: Version bumped from ${PREVIOUS_VERSION} to ${CURRENT_VERSION}${NC}"
+  fi
+done
+
+echo ""
+if [ $VIOLATIONS_FOUND -eq 1 ]; then
+  echo -e "${RED}════════════════════════════════════════════════════════════════${NC}"
+  echo -e "${RED}ERROR: Chart changes detected without version bumps!${NC}"
+  echo -e "${RED}════════════════════════════════════════════════════════════════${NC}"
+  echo -e "${YELLOW}Action required:${NC}"
+  echo -e "  1. Update the 'version' field in Chart.yaml for any modified charts"
+  echo -e "  2. Follow semantic versioning (https://semver.org/):"
+  echo -e "     - MAJOR version for incompatible API changes"
+  echo -e "     - MINOR version for backwards-compatible functionality"
+  echo -e "     - PATCH version for backwards-compatible bug fixes"
+  exit 1
+else
+  echo -e "${GREEN}════════════════════════════════════════════════════════════════${NC}"
+  echo -e "${GREEN}✓ All chart version checks passed!${NC}"
+  echo -e "${GREEN}════════════════════════════════════════════════════════════════${NC}"
+  exit 0
+fi

--- a/.github/workflows/validate-chart-versions.yml
+++ b/.github/workflows/validate-chart-versions.yml
@@ -1,0 +1,69 @@
+name: Validate Chart Versions
+
+on:
+  pull_request:
+    paths:
+      - 'charts/**'
+
+jobs:
+  check-version-bump:
+    runs-on: ubuntu-latest
+    name: Check Chart Version Bumps
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Check for version bumps
+        run: bash .github/scripts/check-version-bump.sh
+
+      - name: Comment on PR if version bump needed
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue_number = context.issue.number;
+            const body = `## ⚠️ Chart Version Bump Required
+
+            One or more charts have been modified but their versions have not been bumped in \`Chart.yaml\`.
+
+            **Action Required:**
+            - Update the \`version\` field in \`Chart.yaml\` for any modified charts
+            - Follow [semantic versioning](https://semver.org/):
+              - **MAJOR** version for incompatible API changes
+              - **MINOR** version for backwards-compatible functionality
+              - **PATCH** version for backwards-compatible bug fixes
+
+            The release workflow will skip charts without version bumps, which can lead to changes being left behind unnoticed.`;
+
+            // Check if we already commented
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+            });
+
+            const botComment = comments.data.find(comment =>
+              comment.user.type === 'Bot' &&
+              comment.body.includes('Chart Version Bump Required')
+            );
+
+            if (botComment) {
+              // Update existing comment
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: body
+              });
+            } else {
+              // Create new comment
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue_number,
+                body: body
+              });
+            }

--- a/README.md
+++ b/README.md
@@ -17,3 +17,12 @@ Port is the Developer Platform meant to supercharge your DevOps and Developers, 
 | [charts/port-k8s-exporter](charts/port-k8s-exporter)   | Port K8s Exporter - export and map K8s objects to Port entities | https://github.com/port-labs/port-k8s-exporter |
 | [charts/port-agent](charts/port-agent)   | Port Agent - consume and invoke Port Self-Service Actions | https://github.com/port-labs/port-agent |
 | [charts/port-ocean](charts/port-ocean)   | Port Ocean - export and map data from 3rd party systems  | https://github.com/port-labs/port-ocean |
+
+## Contributing
+
+When making changes to any chart, you **must** bump the chart version in `Chart.yaml` according to [semantic versioning](https://semver.org/):
+- **MAJOR** version for incompatible API changes
+- **MINOR** version for backwards-compatible functionality additions
+- **PATCH** version for backwards-compatible bug fixes
+
+The CI/CD pipeline will automatically validate that chart versions are bumped when content changes are detected.


### PR DESCRIPTION
## Summary
- Adds pre-merge validation to prevent chart changes from being merged without a corresponding version bump in Chart.yaml
- Implements automated PR check that fails and comments when chart content is modified but the version is unchanged
- Updates documentation with version bump requirements

## Changes

### New Files
1. **`.github/scripts/check-version-bump.sh`** - Validation script that:
   - Detects changes to chart content files (excluding Chart.yaml/Chart.lock)
   - Compares current version with base branch version
   - Fails if content changed but version not bumped
   - Provides clear error messages with semantic versioning guidance

2. **`.github/workflows/validate-chart-versions.yml`** - GitHub Actions workflow that:
   - Triggers on all PRs affecting `charts/**`
   - Executes the version bump check script
   - Posts a helpful comment on the PR if validation fails
   - Blocks merge until version is bumped

### Modified Files
3. **`README.md`** - Added Contributing section documenting:
   - Requirement to bump chart versions for any content changes
   - Semantic versioning guidelines (MAJOR/MINOR/PATCH)
   - Note about automated CI/CD validation

## Problem Solved
Previously, the Release Charts workflow would silently skip publishing when chart content was modified but Chart.yaml version was not bumped. The chart-releaser would detect an existing release tag and no-op without any signal to the author, leading to changes being left behind unnoticed.

This fix catches the issue at PR time with a clear failure and actionable feedback.

## Test Plan
- [x] Script successfully detects when no changes are present
- [x] Workflow triggers only on PRs affecting charts/**
- [x] PR comment provides clear guidance on version bump requirements
- [ ] Test on a real PR with chart changes (will be validated when this PR is opened)

Resolves: PLTFM-35fdc796c

🤖 Generated with [Claude Code](https://claude.com/claude-code)