### PR TITLE
Add Helm chart for Incremental Cron

### DIFF
--- a/charts/port-ocean/Chart.yaml
+++ b/charts/port-ocean/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-ocean
 description: A Helm chart for Port Ocean integrations
 type: application
-version: 0.18.1
+version: 0.19.0
 appVersion: "0.1.0"
 home: https://getport.io/
 sources:

--- a/charts/port-ocean/templates/_helpers.tpl
+++ b/charts/port-ocean/templates/_helpers.tpl
@@ -127,6 +127,27 @@ Get config map name
 {{- printf "%s-le-config" $prefix | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{- define "port-ocean.incrementalSync.configMapName" -}}
+{{ $prefix:= include "port-ocean.metadataNamePrefix" . }}
+{{- printf "%s-incr-config" $prefix | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "port-ocean.incrementalSync.cronJobName" -}}
+{{- $prefix := include "port-ocean.metadataNamePrefix" . -}}
+{{- $cronJobName := printf "%s-incr-cron" $prefix -}}
+{{- if gt (len $cronJobName) 52 -}}
+{{- $maxPrefixLen := int (sub 52 10) -}}
+{{- $truncatedPrefix := trunc $maxPrefixLen $prefix | trimSuffix "-" -}}
+{{- printf "%s-incr-cron" $truncatedPrefix -}}
+{{- else -}}
+{{- $cronJobName -}}
+{{- end -}}
+{{- end }}
+
+{{- define "port-ocean.incrementalSync.schedule" -}}
+{{- (.Values.incrementalSync.worker.interval | default "*/15 * * * *") | toString -}}
+{{- end -}}
+
 {{- define "port-ocean.actionsProcessor.configMapName" -}}
 {{ $prefix:= include "port-ocean.metadataNamePrefix" . }}
 {{- printf "%s-ap-config" $prefix | trunc 63 | trimSuffix "-" }}

--- a/charts/port-ocean/templates/_helpers.tpl
+++ b/charts/port-ocean/templates/_helpers.tpl
@@ -145,7 +145,7 @@ Get config map name
 {{- end }}
 
 {{- define "port-ocean.incrementalSync.schedule" -}}
-{{- (.Values.incrementalSync.worker.interval | default "*/15 * * * *") | toString -}}
+{{- (.Values.incrementalSync.interval | default "*/15 * * * *") | toString -}}
 {{- end -}}
 
 {{- define "port-ocean.actionsProcessor.configMapName" -}}

--- a/charts/port-ocean/templates/configmap-incremental.yaml
+++ b/charts/port-ocean/templates/configmap-incremental.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.incrementalSync.worker.enabled }}
+{{- if .Values.incrementalSync.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,7 +7,7 @@ metadata:
     {{- include "port-ocean.labels" . | nindent 4 }}
 data:
   OCEAN__PORT__BASE_URL: {{ .Values.port.baseUrl | quote }}
-  OCEAN__INITIALIZE_PORT_RESOURCES: "{{ .Values.incrementalSync.worker.initializePortResources | default false }}"
+  OCEAN__INITIALIZE_PORT_RESOURCES: "{{ .Values.incrementalSync.initializePortResources | default false }}"
   {{- if .Values.createPortResourcesOrigin }}
   OCEAN__CREATE_PORT_RESOURCES_ORIGIN: "{{ .Values.createPortResourcesOrigin }}"
   {{- end }}

--- a/charts/port-ocean/templates/configmap-incremental.yaml
+++ b/charts/port-ocean/templates/configmap-incremental.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.incrementalSync.worker.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "port-ocean.incrementalSync.configMapName" . }}
+  labels:
+    {{- include "port-ocean.labels" . | nindent 4 }}
+data:
+  OCEAN__PORT__BASE_URL: {{ .Values.port.baseUrl | quote }}
+  OCEAN__INITIALIZE_PORT_RESOURCES: "{{ .Values.incrementalSync.worker.initializePortResources | default false }}"
+  {{- if .Values.createPortResourcesOrigin }}
+  OCEAN__CREATE_PORT_RESOURCES_ORIGIN: "{{ .Values.createPortResourcesOrigin }}"
+  {{- end }}
+  OCEAN__ALLOW_ENVIRONMENT_VARIABLES_JQ_ACCESS: "{{ if hasKey .Values "allowEnvironmentVariablesJqAccess" }}{{ .Values.allowEnvironmentVariablesJqAccess }}{{ else }}true{{ end }}"
+  {{- if .Values.clientTimeout }}
+  OCEAN__CLIENT_TIMEOUT: "{{ .Values.clientTimeout }}"
+  {{- end }}
+  OCEAN__SEND_RAW_DATA_EXAMPLES: "{{ .Values.sendRawDataExamples | default true }}"
+  OCEAN__EVENT_LISTENER: '{"type":"ONCE"}'
+  {{- if .Values.integration.identifier }}
+  OCEAN__INTEGRATION__IDENTIFIER: "{{ .Values.integration.identifier }}"
+  {{- end }}
+  OCEAN__INTEGRATION__INCREMENTAL_SYNC_ENABLED: "true"
+  {{- if .Values.integration.oauth.enabled }}
+  OCEAN__OAUTH_ACCESS_TOKEN_FILE_PATH: "{{ .Values.integration.oauth.access_token_file_path }}"
+  {{- end }}
+  {{- if .Values.integration.processExecution.mode }}
+  OCEAN__PROCESS_EXECUTION_MODE: "{{ .Values.integration.processExecution.mode }}"
+  {{- if eq .Values.integration.processExecution.mode "multi_process" }}
+  PROMETHEUS_MULTIPROC_DIR: "{{ .Values.integration.processExecution.prometheusMultiProcessDir }}"
+  {{- end }}
+  {{- end }}
+  {{- if .Values.integration.config }}
+  {{- range $key, $value := .Values.integration.config }}
+  {{- if or (kindIs "map" $value) (kindIs "slice" $value) }}
+  OCEAN__INTEGRATION__CONFIG__{{ $key | snakecase | upper }}: {{ $value | toJson | quote }}
+  {{- else }}
+  OCEAN__INTEGRATION__CONFIG__{{ $key | snakecase | upper }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  OCEAN__LAKEHOUSE_ENABLED: "{{ .Values.lakehouseEnabled | default true }}"
+  OCEAN__PROCESSING_MODE: "{{ .Values.processingMode | default "dsp" }}"
+  {{- if .Values.incrementalSync.extraConfig }}
+  {{- range $key, $value := .Values.incrementalSync.extraConfig }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/port-ocean/templates/cron-job/incremental-cron.yaml
+++ b/charts/port-ocean/templates/cron-job/incremental-cron.yaml
@@ -1,7 +1,7 @@
-{{- if .Values.incrementalSync.worker.enabled }}
+{{- if .Values.incrementalSync.enabled }}
 {{- $maxRunTimeSeconds := "" }}
-{{- if .Values.incrementalSync.worker.timeoutMinutes }}
-{{- $maxRunTimeSeconds = (mul .Values.incrementalSync.worker.timeoutMinutes 60) }}
+{{- if .Values.incrementalSync.timeoutMinutes }}
+{{- $maxRunTimeSeconds = (mul .Values.incrementalSync.timeoutMinutes 60) }}
 {{- end }}
 apiVersion: batch/v1
 kind: CronJob
@@ -10,11 +10,11 @@ metadata:
   labels:
     {{- include "port-ocean.labels" . | nindent 4 }}
 spec:
-  failedJobsHistoryLimit: {{ .Values.incrementalSync.worker.failedJobsHistoryLimit }}
-  successfulJobsHistoryLimit: {{ .Values.incrementalSync.worker.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.incrementalSync.failedJobsHistoryLimit }}
+  successfulJobsHistoryLimit: {{ .Values.incrementalSync.successfulJobsHistoryLimit }}
   schedule: {{ include "port-ocean.incrementalSync.schedule" . | squote }}
-  suspend: {{ .Values.incrementalSync.worker.suspend }}
-  concurrencyPolicy: {{ .Values.incrementalSync.worker.concurrencyPolicy | default "Forbid" }}
+  suspend: {{ .Values.incrementalSync.suspend }}
+  concurrencyPolicy: {{ .Values.incrementalSync.concurrencyPolicy | default "Forbid" }}
   jobTemplate:
     metadata:
       generateName: {{ include "port-ocean.metadataNamePrefixShort" . }}-incr-
@@ -79,8 +79,8 @@ spec:
               {{- toYaml .Values.containerSecurityContext | nindent 14 }}
               {{- end }}
             resources:
-              {{- if .Values.incrementalSync.worker.resources }}
-              {{- toYaml .Values.incrementalSync.worker.resources | nindent 14 }}
+              {{- if .Values.incrementalSync.resources }}
+              {{- toYaml .Values.incrementalSync.resources | nindent 14 }}
               {{- end }}
             env:
             {{- if .Values.selfSignedCertificate.enabled }}

--- a/charts/port-ocean/templates/cron-job/incremental-cron.yaml
+++ b/charts/port-ocean/templates/cron-job/incremental-cron.yaml
@@ -1,0 +1,148 @@
+{{- if .Values.incrementalSync.worker.enabled }}
+{{- $maxRunTimeSeconds := "" }}
+{{- if .Values.incrementalSync.worker.timeoutMinutes }}
+{{- $maxRunTimeSeconds = (mul .Values.incrementalSync.worker.timeoutMinutes 60) }}
+{{- end }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "port-ocean.incrementalSync.cronJobName" . }}
+  labels:
+    {{- include "port-ocean.labels" . | nindent 4 }}
+spec:
+  failedJobsHistoryLimit: {{ .Values.incrementalSync.worker.failedJobsHistoryLimit }}
+  successfulJobsHistoryLimit: {{ .Values.incrementalSync.worker.successfulJobsHistoryLimit }}
+  schedule: {{ include "port-ocean.incrementalSync.schedule" . | squote }}
+  suspend: {{ .Values.incrementalSync.worker.suspend }}
+  concurrencyPolicy: {{ .Values.incrementalSync.worker.concurrencyPolicy | default "Forbid" }}
+  jobTemplate:
+    metadata:
+      generateName: {{ include "port-ocean.metadataNamePrefixShort" . }}-incr-
+      namespace: {{ .Release.Namespace }}
+      labels:
+        app: {{ include "port-ocean.incrementalSync.cronJobName" . }}
+        integrationUniqueIncrementalCronKey: {{ .Release.Name }}
+        {{- include "port-ocean.selectorLabels" . | indent 8 }}
+    spec:
+      backoffLimit: 0
+      {{- if $maxRunTimeSeconds }}
+      activeDeadlineSeconds: {{ $maxRunTimeSeconds }}
+      {{- end }}
+      template:
+        metadata:
+          {{- $podAnnotations := .Values.podAnnotations | default dict }}
+          {{- $cronAnnotations := (.Values.workload.cron.annotations | default dict) }}
+          {{- $annotations := merge (dict) $podAnnotations $cronAnnotations }}
+          {{- with $annotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          labels:
+            app: {{ include "port-ocean.incrementalSync.cronJobName" . }}
+            {{- include "port-ocean.labels" . | nindent 12 }}
+        spec:
+          {{- if or .Values.podServiceAccount.name .Values.podServiceAccount.create }}
+          serviceAccountName: {{ include "port-ocean.serviceAccountName" . }}
+          {{- end }}
+          restartPolicy: Never
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- if .Values.podSecurityContext }}
+            {{- toYaml .Values.podSecurityContext | nindent 12 }}
+            {{- end }}
+          initContainers:
+            {{- if .Values.extraInitContainers }}
+            {{- tpl (toYaml .Values.extraInitContainers) . | nindent 12 }}
+            {{- end }}
+            {{- if .Values.postgresql.enabled }}
+            - name: wait-for-postgresql
+              image: {{ .Values.postgresql.image }}
+              command:
+                - sh
+                - -c
+                - |
+                  until pg_isready -h {{ .Release.Name }}-postgresql -p 5432 -U {{ .Values.postgresql.global.postgresql.auth.username }}; do
+                    echo "Waiting for PostgreSQL to be ready..."
+                    sleep 2
+                  done
+                  echo "PostgreSQL is ready!"
+            {{- end }}
+          containers:
+          - name: {{ include "port-ocean.containerName" . }}
+            imagePullPolicy: {{ .Values.imagePullPolicy }}
+            image: {{ include "port-ocean.image" . }}
+            securityContext:
+              {{- if .Values.containerSecurityContext }}
+              {{- toYaml .Values.containerSecurityContext | nindent 14 }}
+              {{- end }}
+            resources:
+              {{- if .Values.incrementalSync.worker.resources }}
+              {{- toYaml .Values.incrementalSync.worker.resources | nindent 14 }}
+              {{- end }}
+            env:
+            {{- if .Values.selfSignedCertificate.enabled }}
+              - name: SSL_CERT_FILE
+                value: /etc/ssl/certs/ca-certificates.crt
+              - name: REQUESTS_CA_BUNDLE
+                value: /etc/ssl/certs/ca-certificates.crt
+            {{- end }}
+            {{- if .Values.extraEnv }}
+              {{- tpl (toYaml .Values.extraEnv) . | nindent 14 }}
+            {{- end }}
+            envFrom:
+              - configMapRef:
+                  name: {{ include "port-ocean.incrementalSync.configMapName" . }}
+              {{- include "port-ocean.additionalSecrets" . | nindent 14 }}
+            volumeMounts:
+              - name: ocean-tmp
+                mountPath: /tmp/ocean
+            {{- if .Values.extraVolumeMounts }}
+              {{- tpl (toYaml .Values.extraVolumeMounts) . | nindent 14 }}
+            {{- end }}
+            {{- if .Values.selfSignedCertificate.enabled }}
+              - name: certificates
+                mountPath: /usr/local/share/ca-certificates/cert.crt
+                subPath: cert.crt
+                readOnly: true
+            {{- end }}
+          volumes:
+            - name: ocean-tmp
+              emptyDir: { }
+            {{- if .Values.extraVolumes }}
+            {{- tpl (toYaml .Values.extraVolumes) . | nindent 12 }}
+            {{- end }}
+            {{- if and .Values.selfSignedCertificate.enabled .Values.selfSignedCertificate.secret.useExistingSecret }}
+            - name: certificates
+              projected:
+                sources:
+                  - secret:
+                      name: {{ .Values.selfSignedCertificate.secret.name }}
+                      items:
+                        - key: {{ .Values.selfSignedCertificate.secret.key }}
+                          path: cert.crt
+            {{- else if .Values.selfSignedCertificate.enabled }}
+            - name: certificates
+              projected:
+                sources:
+                  - secret:
+                      name: {{ include "port-ocean.selfSignedCertName" . }}
+                      items:
+                        - key: crt
+                          path: cert.crt
+            {{- end }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/charts/port-ocean/values.yaml
+++ b/charts/port-ocean/values.yaml
@@ -171,6 +171,28 @@ selfSignedCertificate:
     key: crt
     useExistingSecret: false
 
+incrementalSync:
+  worker:
+    enabled: false
+    # Cron expression for the incremental CronJob (set by integ-service via parseIntervalToCron).
+    interval: null
+    # Skip a scheduled tick while a job is still running; do not kill in-flight pods.
+    concurrencyPolicy: Forbid
+    initializePortResources: false
+    suspend: false
+    failedJobsHistoryLimit: 1
+    successfulJobsHistoryLimit: 1
+    # Optional hard cap on job duration (minutes). Unset = no activeDeadlineSeconds.
+    timeoutMinutes: null
+    resources:
+      requests:
+        memory: "512Mi"
+        cpu: "100m"
+      limits:
+        memory: "512Mi"
+        cpu: "800m"
+  extraConfig: { }
+
 liveEvents:
   baseUrl: ""
   worker:

--- a/charts/port-ocean/values.yaml
+++ b/charts/port-ocean/values.yaml
@@ -176,25 +176,24 @@ selfSignedCertificate:
     useExistingSecret: false
 
 incrementalSync:
-  worker:
-    enabled: false
-    # Cron expression for the incremental CronJob (set by integ-service via parseIntervalToCron).
-    interval: null
-    # Skip a scheduled tick while a job is still running; do not kill in-flight pods.
-    concurrencyPolicy: Forbid
-    initializePortResources: false
-    suspend: false
-    failedJobsHistoryLimit: 1
-    successfulJobsHistoryLimit: 1
-    # Optional hard cap on job duration (minutes). Unset = no activeDeadlineSeconds.
-    timeoutMinutes: null
-    resources:
-      requests:
-        memory: "512Mi"
-        cpu: "100m"
-      limits:
-        memory: "512Mi"
-        cpu: "800m"
+  enabled: false
+  # Cron expression for the incremental CronJob (set by integ-service via parseIntervalToCron).
+  interval: null
+  # Skip a scheduled tick while a job is still running; do not kill in-flight pods.
+  concurrencyPolicy: Forbid
+  initializePortResources: false
+  suspend: false
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 1
+  # Optional hard cap on job duration (minutes). Unset = no activeDeadlineSeconds.
+  timeoutMinutes: null
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+      cpu: "800m"
   extraConfig: { }
 
 liveEvents:


### PR DESCRIPTION
# Description

What
Add incremental sync CronJob + ConfigMap to port-ocean v0.19.0 (incrementalSync.worker).

Why
Run cursor-based incremental sync on a schedule, separate from full resync.

How
When incrementalSync.worker.enabled=true, chart deploys -incr-cron (ONCE + incremental flag) and -incr-config. integ-service sets enabled + cron interval.

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

