### PR TITLE
fix(port-ocean): allow live-events replicaCount of 0

### DIFF
--- a/charts/port-ocean/Chart.yaml
+++ b/charts/port-ocean/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-ocean
 description: A Helm chart for Port Ocean integrations
 type: application
-version: 0.19.0
+version: 0.19.1
 appVersion: "0.1.0"
 home: https://getport.io/
 sources:

--- a/charts/port-ocean/templates/deployment-live-events.yaml
+++ b/charts/port-ocean/templates/deployment-live-events.yaml
@@ -11,7 +11,11 @@ spec:
     {{- toYaml . | trim | nindent 4 }}
   {{- end }}
   revisionHistoryLimit: {{ .Values.liveEvents.deployment.revisionHistoryLimit }}
-  replicas: {{ .Values.liveEvents.worker.replicaCount | default 1 }}
+  {{- if hasKey .Values.liveEvents.worker "replicaCount" }}
+  replicas: {{ .Values.liveEvents.worker.replicaCount }}
+  {{- else }}
+  replicas: 1
+  {{- end }}
   selector:
     matchLabels:
       app: {{ include "port-ocean.liveEvents.deploymentName" . }}


### PR DESCRIPTION
## Summary
- Fix live-events deployment replica handling so an explicit `replicaCount: 0` is respected instead of falling back to 1
- Bump `port-ocean` chart version to `0.19.1`

## Context
Helm's `default` filter treats `0` as empty. The previous template used `replicaCount | default 1`, which meant setting `liveEvents.worker.replicaCount: 0` (e.g. to scale down live-events during load tests) still rendered `replicas: 1`.

This change uses `hasKey` to default only when the key is unset, while honoring explicit zero values.



Made with [Cursor](https://cursor.com)