### PR TITLE
fix(port-ocean): honor false resyncOnInstall/resyncOnUpgrade values

### DIFF
--- a/charts/port-ocean/Chart.yaml
+++ b/charts/port-ocean/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-ocean
 description: A Helm chart for Port Ocean integrations
 type: application
-version: 0.19.1
+version: 0.19.2
 appVersion: "0.1.0"
 home: https://getport.io/
 sources:

--- a/charts/port-ocean/templates/cron-job/installation-resync-job.yml
+++ b/charts/port-ocean/templates/cron-job/installation-resync-job.yml
@@ -1,5 +1,5 @@
-{{- $resyncOnInstall := (.Values.workload.cron).resyncOnInstall | default true }}
-{{- $resyncOnUpgrade := (.Values.workload.cron).resyncOnUpgrade | default true }}
+{{- $resyncOnInstall := ternary .Values.workload.cron.resyncOnInstall true (hasKey .Values.workload.cron "resyncOnInstall") }}
+{{- $resyncOnUpgrade := ternary .Values.workload.cron.resyncOnUpgrade true (hasKey .Values.workload.cron "resyncOnUpgrade") }}
 {{- if and (eq .Values.workload.kind "CronJob") (or $resyncOnInstall $resyncOnUpgrade) }}
 {{- $jobName := (print (randAlphaNum 4) "-" .Release.Revision) | lower }}
 apiVersion: batch/v1


### PR DESCRIPTION
## Summary
- Fix `workload.cron.resyncOnInstall` and `resyncOnUpgrade` so explicit `false` is respected
- Bump `port-ocean` chart version to `0.19.2`

## Context
Helm's `default` filter treats `false` as empty. The installation resync hook template used `| default true`, so setting either flag to `false` still rendered the post-install/post-upgrade hook Job.

This uses `hasKey` + `ternary` so unset keys still default to `true`, while explicit `false` disables the hook (when both are false).

Made with [Cursor](https://cursor.com)