### PR TITLE
[Ocean] Change the default execution mode in ocean to single_process

### DIFF
--- a/charts/port-ocean/Chart.yaml
+++ b/charts/port-ocean/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-ocean
 description: A Helm chart for Port Ocean integrations
 type: application
-version: 0.19.2
+version: 0.19.3
 appVersion: "0.1.0"
 home: https://getport.io/
 sources:

--- a/charts/port-ocean/values.yaml
+++ b/charts/port-ocean/values.yaml
@@ -158,7 +158,7 @@ integration:
   secrets: { }
   extraConfig: { }
   processExecution:
-    mode: "multi_process"
+    mode: "single_process"
     prometheusMultiProcessDir: "/tmp/ocean/prometheus/metrics"
   oauth:
     enabled: false


### PR DESCRIPTION
# Description

What - Changed the default execution engine in the `values.yaml` to single_process
Why - Deprecation of the multi_process execution engine
How - Change the default value in the values.yaml

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

