### PR TITLE
Added labels, resources and security context on installation-resync-job

### DIFF
--- a/charts/port-ocean/Chart.yaml
+++ b/charts/port-ocean/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-ocean
 description: A Helm chart for Port Ocean integrations
 type: application
-version: 0.19.3
+version: 0.19.4
 appVersion: "0.1.0"
 home: https://getport.io/
 sources:

--- a/charts/port-ocean/Chart.yaml
+++ b/charts/port-ocean/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-ocean
 description: A Helm chart for Port Ocean integrations
 type: application
-version: 0.19.4
+version: 0.20.0
 appVersion: "0.1.0"
 home: https://getport.io/
 sources:

--- a/charts/port-ocean/templates/cron-job/installation-resync-job.yml
+++ b/charts/port-ocean/templates/cron-job/installation-resync-job.yml
@@ -9,17 +9,34 @@ metadata:
     helm.sh/hook: post-install, post-upgrade
     helm.sh/hook-delete-policy: hook-succeeded
   name: init-sync-{{ .Release.Name }}-{{ $jobName }}
+  labels:
+    {{- include "port-ocean.labels" . | nindent 4 }}
 spec:
   ttlSecondsAfterFinished: 600
   activeDeadlineSeconds: 180
   backoffLimit: 0
   template:
+    metadata:
+      labels:
+        {{- include "port-ocean.labels" . | nindent 8 }}
     spec:
       activeDeadlineSeconds: 180
+      securityContext:
+        {{- if .Values.podSecurityContext }}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- end }}
       containers:
         - name: kubectl
           image: {{ .Values.workload.cron.kubectlImage }}
           command: [ "sh", "-c" ]
+          securityContext:
+            {{- if .Values.containerSecurityContext }}
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- if .Values.resources }}
+            {{- toYaml .Values.resources | nindent 12 }}
+            {{- end }}
           env:
             - name: TOKEN
               valueFrom:


### PR DESCRIPTION
# Description

What - Added labels, resources and security context to installation-resync-job.yml
Why - Some clusters enforce those fields which led to deployments being blocked (https://getport.atlassian.net/browse/PORT-17808)
How - Matched values based on what exists on cron.yml

## Type of change

Please leave one option from the following and delete the rest:

- [X] Bug fix (non-breaking change which fixes an issue)

## Validation method
1. Ran helm template and saw that the fields were missing before, then added after the change
2. Generated policy files based on the issue mentioned, and used kyverno to validate that it fails on main and passes on my branch
