### PR TITLE
Feat: Add ocean-gateway Helm chart and enable Redis stream consumer on port-ocean main deployment

### DIFF
--- a/.github/workflows/validate-ocean-gateway.yml
+++ b/.github/workflows/validate-ocean-gateway.yml
@@ -45,6 +45,13 @@ jobs:
           --set redis.enabled=true \
           --set redis.auth.password=pass > /dev/null
 
+    - name: Template — ingress enabled
+      run: |
+        helm template t . \
+          --set redis.url=redis:6379 \
+          --set ingress.enabled=true \
+          --set ingress.host=gateway.example.com > /dev/null
+
     - name: Template — existing secret
       run: |
         helm template t . \

--- a/.github/workflows/validate-ocean-gateway.yml
+++ b/.github/workflows/validate-ocean-gateway.yml
@@ -1,0 +1,59 @@
+name: Helm Chart Validation
+
+on:
+  pull_request:
+    paths:
+      - charts/ocean-gateway/**
+
+jobs:
+  validate:
+    defaults:
+      run:
+        working-directory: charts/ocean-gateway/
+    runs-on: ubuntu-latest
+    name: Validate Helm Chart
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v5
+
+    - name: Set up Helm
+      uses: azure/setup-helm@v3
+
+    - name: Build dependencies of Helm Chart
+      run: |
+        helm repo add bitnami https://charts.bitnami.com/bitnami
+        helm repo update
+        helm dependency update
+
+    - name: Lint Helm Chart — external Redis
+      run: helm lint . --set redis.url=redis:6379
+
+    - name: Lint Helm Chart — bundled Redis
+      run: helm lint . --set redis.enabled=true
+
+    - name: Template — external Redis
+      run: |
+        helm template t . \
+          --set redis.url=redis:6379 \
+          --set redis.username=user \
+          --set redis.password=pass > /dev/null
+
+    - name: Template — bundled Redis
+      run: |
+        helm template t . \
+          --set redis.enabled=true \
+          --set redis.auth.password=pass > /dev/null
+
+    - name: Template — existing secret
+      run: |
+        helm template t . \
+          --set redis.existingSecret=ext-redis > /dev/null
+
+    - name: Template — url required when external Redis is not configured
+      run: |
+        if helm template t . > /dev/null 2>&1; then
+          echo "FAIL: expected error when redis.url and redis.existingSecret are both unset" >&2
+          exit 1
+        fi
+        echo "PASS: chart correctly requires redis.url without bundled Redis or an existing secret"

--- a/.github/workflows/validate-ocean-gateway.yml
+++ b/.github/workflows/validate-ocean-gateway.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - charts/ocean-gateway/**
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     defaults:
@@ -20,6 +23,9 @@ jobs:
     - name: Set up Helm
       uses: azure/setup-helm@v3
 
+    - name: Create k8s Kind Cluster
+      uses: helm/kind-action@v1.5.0
+
     - name: Build dependencies of Helm Chart
       run: |
         helm repo add bitnami https://charts.bitnami.com/bitnami
@@ -32,35 +38,131 @@ jobs:
     - name: Lint Helm Chart — bundled Redis
       run: helm lint . --set redis.enabled=true
 
-    - name: Template — external Redis
+    - name: Validate Helm Chart
       run: |
-        helm template t . \
+        set -euo pipefail
+
+        dry_run() {
+          helm template "$1" . "${@:2}" | kubectl apply --dry-run=client -f -
+        }
+
+        assert_contains() {
+          local manifest=$1 pattern=$2 message=$3
+          echo "$manifest" | grep -q "$pattern" || {
+            echo "FAIL: $message (expected pattern: $pattern)" >&2
+            exit 1
+          }
+        }
+
+        assert_not_contains() {
+          local manifest=$1 pattern=$2 message=$3
+          if echo "$manifest" | grep -q "$pattern"; then
+            echo "FAIL: $message (unexpected pattern: $pattern)" >&2
+            exit 1
+          fi
+        }
+
+        echo "=== External Redis (chart-managed Secret) ==="
+        external_manifest=$(helm template external . \
           --set redis.url=redis:6379 \
           --set redis.username=user \
-          --set redis.password=pass > /dev/null
+          --set redis.password=pass)
+        echo "$external_manifest" | kubectl apply --dry-run=client -f -
+        assert_contains "$external_manifest" 'REDIS_OCEAN_LIVE_EVENTS_URL: "redis:6379"' \
+          "ConfigMap should set Redis URL for external Redis"
+        assert_contains "$external_manifest" 'REDIS_OCEAN_LIVE_EVENTS_PASSWORD' \
+          "chart should create a Secret with the Redis password"
+        assert_contains "$external_manifest" 'REDIS_OCEAN_LIVE_EVENTS_ENABLE_TLS: "false"' \
+          "ConfigMap should expose Redis TLS setting"
+        assert_contains "$external_manifest" 'checksum/redis-credentials:' \
+          "Deployment should annotate Redis credential checksum"
+        assert_contains "$external_manifest" 'tcpSocket:' \
+          "liveness probe should use tcpSocket (no Redis ping)"
+        assert_contains "$external_manifest" 'path: /healthz' \
+          "readiness probe should hit /healthz"
+        assert_contains "$external_manifest" 'serviceAccountName: default' \
+          "Deployment should use the namespace default ServiceAccount when serviceAccount.create is false"
+        assert_not_contains "$external_manifest" 'kind: ServiceAccount' \
+          "ServiceAccount should not be created when serviceAccount.create is false"
+        assert_not_contains "$external_manifest" 'name: wait-for-redis' \
+          "external Redis should not deploy the wait-for-redis init container"
 
-    - name: Template — bundled Redis
-      run: |
-        helm template t . \
+        echo "=== Dedicated ServiceAccount (opt-in) ==="
+        sa_manifest=$(helm template sa . \
+          --set redis.url=redis:6379 \
+          --set redis.password=pass \
+          --set serviceAccount.create=true)
+        echo "$sa_manifest" | kubectl apply --dry-run=client -f -
+        assert_contains "$sa_manifest" 'kind: ServiceAccount' \
+          "chart should create a ServiceAccount when serviceAccount.create is true"
+        assert_contains "$sa_manifest" 'serviceAccountName: sa-ocean-gateway' \
+          "Deployment should use the dedicated ServiceAccount"
+
+        echo "=== Bundled Redis ==="
+        bundled_manifest=$(helm template bundled . \
           --set redis.enabled=true \
-          --set redis.auth.password=pass > /dev/null
+          --set redis.auth.password=pass)
+        echo "$bundled_manifest" | kubectl apply --dry-run=client -f -
+        assert_contains "$bundled_manifest" 'name: wait-for-redis' \
+          "bundled Redis should include the wait-for-redis init container"
+        assert_contains "$bundled_manifest" 'secretKeyRef:' \
+          "init container should load Redis password via secretKeyRef"
+        assert_contains "$bundled_manifest" 'key: REDIS_OCEAN_LIVE_EVENTS_PASSWORD' \
+          "init container should read REDIS_OCEAN_LIVE_EVENTS_PASSWORD from the Secret"
+        assert_contains "$bundled_manifest" 'bitnamisecure/redis' \
+          "bundled Redis should use bitnamisecure/redis images"
+        assert_not_contains "$bundled_manifest" 'bitnami/redis:' \
+          "bundled Redis must not reference deprecated bitnami/redis images"
 
-    - name: Template — ingress enabled
-      run: |
-        helm template t . \
+        echo "=== Existing Secret ==="
+        existing_manifest=$(helm template existing . \
+          --set redis.existingSecret=ext-redis)
+        echo "$existing_manifest" | kubectl apply --dry-run=client -f -
+        assert_contains "$existing_manifest" 'name: ext-redis' \
+          "Deployment should reference the pre-existing Secret"
+        assert_not_contains "$existing_manifest" 'REDIS_OCEAN_LIVE_EVENTS_URL' \
+          "ConfigMap should not set Redis URL when existingSecret is used"
+        assert_not_contains "$existing_manifest" 'kind: Secret' \
+          "chart should not create a gateway Secret when existingSecret is set"
+
+        echo "=== Ingress enabled ==="
+        dry_run ingress \
           --set redis.url=redis:6379 \
           --set ingress.enabled=true \
-          --set ingress.host=gateway.example.com > /dev/null
+          --set ingress.host=gateway.example.com
 
-    - name: Template — existing secret
-      run: |
-        helm template t . \
-          --set redis.existingSecret=ext-redis > /dev/null
+        echo "=== ingress.host required when ingress is enabled ==="
+        if helm template invalid-ingress . \
+          --set redis.url=redis:6379 \
+          --set ingress.enabled=true > /dev/null 2>&1; then
+          echo "FAIL: expected error when ingress.enabled=true without ingress.host" >&2
+          exit 1
+        fi
 
-    - name: Template — url required when external Redis is not configured
-      run: |
-        if helm template t . > /dev/null 2>&1; then
+        echo "=== External Redis with TLS ==="
+        tls_manifest=$(helm template tls . \
+          --set redis.url=redis.example.com:6380 \
+          --set redis.password=pass \
+          --set redis.tls.enabled=true)
+        echo "$tls_manifest" | kubectl apply --dry-run=client -f -
+        assert_contains "$tls_manifest" 'REDIS_OCEAN_LIVE_EVENTS_ENABLE_TLS: "true"' \
+          "ConfigMap should enable Redis TLS when redis.tls.enabled is true"
+
+        echo "=== redis.url required without bundled Redis or existingSecret ==="
+        if helm template invalid . > /dev/null 2>&1; then
           echo "FAIL: expected error when redis.url and redis.existingSecret are both unset" >&2
           exit 1
         fi
-        echo "PASS: chart correctly requires redis.url without bundled Redis or an existing secret"
+
+        echo "=== incompatible redis.enabled + redis.existingSecret ==="
+        if helm template invalid-redis-combo . \
+          --set redis.enabled=true \
+          --set redis.existingSecret=ext-redis > /dev/null 2>&1; then
+          echo "FAIL: expected error when redis.enabled=true and redis.existingSecret are both set" >&2
+          exit 1
+        fi
+
+        echo "PASS: all chart scenarios validated"
+
+    - name: Verify bundled Redis image exists
+      run: docker manifest inspect docker.io/bitnamisecure/redis:latest

--- a/.github/workflows/validate-ocean-gateway.yml
+++ b/.github/workflows/validate-ocean-gateway.yml
@@ -162,6 +162,14 @@ jobs:
           exit 1
         fi
 
+        echo "=== redis.username not allowed with bundled Redis ==="
+        if helm template invalid-redis-username . \
+          --set redis.enabled=true \
+          --set redis.username=foo > /dev/null 2>&1; then
+          echo "FAIL: expected error when redis.enabled=true and redis.username is set" >&2
+          exit 1
+        fi
+
         echo "PASS: all chart scenarios validated"
 
     - name: Verify bundled Redis image exists

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Port is the Developer Platform meant to supercharge your DevOps and Developers, 
 | [charts/port-k8s-exporter](charts/port-k8s-exporter)   | Port K8s Exporter - export and map K8s objects to Port entities | https://github.com/port-labs/port-k8s-exporter |
 | [charts/port-agent](charts/port-agent)   | Port Agent - consume and invoke Port Self-Service Actions | https://github.com/port-labs/port-agent |
 | [charts/port-ocean](charts/port-ocean)   | Port Ocean - export and map data from 3rd party systems  | https://github.com/port-labs/port-ocean |
+| [charts/ocean-gateway](charts/ocean-gateway)   | Ocean Gateway - on-prem live-event webhook ingress to Redis streams | https://github.com/port-labs/ocean-gateway |
 
 ## Contributing
 

--- a/charts/ocean-gateway/.helmignore
+++ b/charts/ocean-gateway/.helmignore
@@ -1,0 +1,7 @@
+# Patterns to ignore when building packages.
+.DS_Store
+*.orig
+*.swp
+.git/
+.gitignore
+*.md

--- a/charts/ocean-gateway/Chart.lock
+++ b/charts/ocean-gateway/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 20.13.4
+digest: sha256:9d0e9c38a82bd62fff83be7f0f88a1d872f781fc9feda04957665e5bab1835c8
+generated: "2026-07-23T17:36:24.389811+03:00"

--- a/charts/ocean-gateway/Chart.yaml
+++ b/charts/ocean-gateway/Chart.yaml
@@ -5,7 +5,7 @@ description: >
   Accepts webhook events and writes them synchronously to per-integration
   Redis streams, which Ocean integrations consume via XREADGROUP.
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: "1.0.0"
 home: https://getport.io/
 sources:

--- a/charts/ocean-gateway/Chart.yaml
+++ b/charts/ocean-gateway/Chart.yaml
@@ -1,0 +1,27 @@
+apiVersion: v2
+name: ocean-gateway
+description: >
+  Stateless live-event gateway for Port Ocean integrations.
+  Accepts webhook events and writes them synchronously to per-integration
+  Redis streams, which Ocean integrations consume via XREADGROUP.
+type: application
+version: 0.2.0
+appVersion: "1.0.0"
+home: https://getport.io/
+sources:
+  - https://github.com/port-labs/ocean-gateway
+dependencies:
+  - name: redis
+    version: 20.13.4
+    repository: https://charts.bitnami.com/bitnami
+    condition: redis.enabled
+maintainers:
+  - name: Port
+    email: support@getport.io
+icon: https://port-graphical-assets.s3.eu-west-1.amazonaws.com/Port+Logo.svg
+keywords:
+  - port
+  - ocean
+  - gateway
+  - live-events
+  - webhooks

--- a/charts/ocean-gateway/Chart.yaml
+++ b/charts/ocean-gateway/Chart.yaml
@@ -5,7 +5,7 @@ description: >
   Accepts webhook events and writes them synchronously to per-integration
   Redis streams, which Ocean integrations consume via XREADGROUP.
 type: application
-version: 0.3.0
+version: 0.1.0
 appVersion: "1.0.0"
 home: https://getport.io/
 sources:

--- a/charts/ocean-gateway/README.md
+++ b/charts/ocean-gateway/README.md
@@ -1,0 +1,114 @@
+# Ocean Gateway
+
+Ocean Gateway is a stateless live-event webhook ingress for on-premises Port Ocean
+deployments. It accepts provider webhooks and writes them synchronously to Redis
+Streams, which Ocean integrations consume via `XREADGROUP`.
+
+## Introduction
+
+This chart installs Ocean Gateway via a `Deployment` resource. Optionally deploy a
+bundled Redis instance (Bitnami subchart) or connect to an existing Redis cluster.
+
+## Usage
+
+[Helm](https://helm.sh) must be installed to use the charts. Please refer to
+Helm's [documentation](https://helm.sh/docs) to get started.
+
+Once Helm has been set up correctly, add the repo as follows:
+
+    helm repo add port-labs https://port-labs.github.io/helm-charts
+
+If you had already added this repo earlier, run `helm repo update` to retrieve
+the latest versions of the packages. You can then run `helm search repo
+port-labs` to see the charts.
+
+### With bundled Redis
+
+For clusters without an existing Redis instance:
+
+```bash
+helm upgrade --install ocean-gateway port-labs/ocean-gateway \
+  --create-namespace --namespace ocean-gateway \
+  --set redis.enabled=true \
+  --set redis.auth.password=<strong-password> \
+  --set ingress.enabled=true \
+  --set ingress.className=nginx \
+  --set ingress.host=gateway.example.com
+```
+
+### With external Redis
+
+```bash
+helm upgrade --install ocean-gateway port-labs/ocean-gateway \
+  --create-namespace --namespace ocean-gateway \
+  --set redis.url=redis.example.svc.cluster.local:6379 \
+  --set redis.password=<password> \
+  --set ingress.enabled=true \
+  --set ingress.className=nginx \
+  --set ingress.host=gateway.example.com
+```
+
+Configure webhook providers to POST to:
+
+```
+https://gateway.example.com/live-events/<liveEventsUUID>/integration/<webhookSuffix>
+```
+
+Ocean integrations must use the **same Redis** instance. See the
+[port-ocean chart](../port-ocean/README.md) for live-events consumer configuration.
+
+To uninstall the chart:
+
+    helm uninstall ocean-gateway --namespace ocean-gateway
+
+## Configuration
+
+The following table lists the main configuration parameters and default values.
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `replicaCount` | Number of gateway replicas (ignored when autoscaling is enabled) | `1` |
+| `image.repository` | Gateway image repository | `ghcr.io/port-labs/ocean-gateway` |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `image.tag` | Image tag (defaults to chart `appVersion` when empty) | `""` |
+| `imagePullSecrets` | Image pull secrets | `[]` |
+| `redis.enabled` | Deploy bundled Bitnami Redis | `false` |
+| `redis.url` | External Redis address (`host:port`). Required when `redis.enabled=false` and `redis.existingSecret` is unset | `""` |
+| `redis.username` | External Redis username (stored in a Secret when set) | `""` |
+| `redis.password` | External Redis password (stored in a Secret when set) | `""` |
+| `redis.existingSecret` | Pre-existing Secret with `REDIS_OCEAN_GATEWAY_URL` / `_USERNAME` / `_PASSWORD` | `""` |
+| `redis.auth.password` | Bundled Redis password (also used by the gateway when `redis.enabled=true`) | `"changeme"` |
+| `redis.master.persistence.enabled` | Enable persistence for bundled Redis | `true` |
+| `redis.master.persistence.size` | PVC size for bundled Redis | `8Gi` |
+| `stream.eventTTL` | Trim stream entries older than this via `XADD MINID` | `"1h"` |
+| `stream.streamTTL` | Idle stream key expiry, refreshed on each write | `"1h"` |
+| `stream.maxLen` | Approx `MAXLEN` per stream (ignored when `eventTTL` > 0) | `0` |
+| `write.maxRetries` | Per-request `XADD` retries before returning 503 | `2` |
+| `write.backoffBase` | Initial retry backoff | `"50ms"` |
+| `service.type` | Kubernetes Service type | `ClusterIP` |
+| `service.port` | Service and container HTTP port | `8080` |
+| `ingress.enabled` | Enable Ingress for external webhook providers | `false` |
+| `ingress.className` | Ingress class name | `""` |
+| `ingress.annotations` | Ingress annotations | `{}` |
+| `ingress.host` | Ingress hostname (required when ingress is enabled) | `null` |
+| `ingress.path` | Ingress path | `/` |
+| `ingress.pathType` | Ingress path type | `Prefix` |
+| `ingress.tls` | Ingress TLS configuration | `[]` |
+| `autoscaling.enabled` | Enable Horizontal Pod Autoscaler | `false` |
+| `autoscaling.minReplicas` | HPA minimum replicas | `1` |
+| `autoscaling.maxReplicas` | HPA maximum replicas | `10` |
+| `autoscaling.targetCPUUtilizationPercentage` | HPA CPU target | `80` |
+| `resources` | Container resource requests and limits | see `values.yaml` |
+| `livenessProbe.enabled` | Enable liveness probe (`/healthz`) | `true` |
+| `readinessProbe.enabled` | Enable readiness probe (`/healthz`) | `true` |
+
+## Producer contract
+
+| Status | Meaning |
+|--------|---------|
+| `202 Accepted` | Event is durably stored in the Redis stream |
+| `503` | Redis temporarily unavailable — producer must retry |
+
+## Source
+
+Application source code: https://github.com/port-labs/ocean-gateway

--- a/charts/ocean-gateway/README.md
+++ b/charts/ocean-gateway/README.md
@@ -48,6 +48,12 @@ helm upgrade --install ocean-gateway port-labs/ocean-gateway \
   --set ingress.host=gateway.example.com
 ```
 
+For managed Redis with in-transit encryption (TLS), also set:
+
+```bash
+  --set redis.tls.enabled=true
+```
+
 Configure webhook providers to POST to:
 
 ```
@@ -69,14 +75,25 @@ The following table lists the main configuration parameters and default values.
 |-----------|-------------|---------|
 | `replicaCount` | Number of gateway replicas (ignored when autoscaling is enabled) | `1` |
 | `image.repository` | Gateway image repository | `ghcr.io/port-labs/ocean-gateway` |
-| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
-| `image.tag` | Image tag (defaults to chart `appVersion` when empty) | `""` |
+| `image.pullPolicy` | Image pull policy | `Always` |
+| `image.tag` | Image tag (defaults to `latest` when empty) | `"latest"` |
 | `imagePullSecrets` | Image pull secrets | `[]` |
+| `serviceAccount.create` | Create a dedicated ServiceAccount for gateway pods | `false` |
+| `serviceAccount.annotations` | Annotations for the ServiceAccount (e.g. cloud workload identity) | `{}` |
+| `serviceAccount.name` | ServiceAccount name override (`""` uses the release fullname when `create=true`) | `""` |
+| `initContainer.securityContext` | Security context for the wait-for-redis init container | see `values.yaml` |
+| `initContainer.resources` | Resources for the wait-for-redis init container | see `values.yaml` |
 | `redis.enabled` | Deploy bundled Bitnami Redis | `false` |
+| `redis.image.registry` | Bundled Redis image registry (also used by the wait-for-redis init container) | `docker.io` |
+| `redis.image.repository` | Bundled Redis image repository | `bitnamisecure/redis` |
+| `redis.image.tag` | Bundled Redis image tag | `latest` |
+| `redis.global.security.allowInsecureImages` | Allow non-default Bitnami images in the Redis subchart | `true` |
 | `redis.url` | External Redis address (`host:port`). Required when `redis.enabled=false` and `redis.existingSecret` is unset | `""` |
 | `redis.username` | External Redis username (stored in a Secret when set) | `""` |
 | `redis.password` | External Redis password (stored in a Secret when set) | `""` |
-| `redis.existingSecret` | Pre-existing Secret with `REDIS_OCEAN_GATEWAY_URL` / `_USERNAME` / `_PASSWORD` | `""` |
+| `redis.tls.enabled` | Enable TLS for external Redis (`REDIS_OCEAN_LIVE_EVENTS_ENABLE_TLS`); use for managed Redis with in-transit encryption | `false` |
+| `redis.existingSecret` | Pre-existing Secret with `REDIS_OCEAN_LIVE_EVENTS_URL` / `_USERNAME` / `_PASSWORD` / `_ENABLE_TLS` | `""` |
+| `redis.credentialsRevision` | Arbitrary string; bump after out-of-band `existingSecret` rotation to roll pods | `""` |
 | `redis.auth.password` | Bundled Redis password (also used by the gateway when `redis.enabled=true`) | `"changeme"` |
 | `redis.master.persistence.enabled` | Enable persistence for bundled Redis | `true` |
 | `redis.master.persistence.size` | PVC size for bundled Redis | `8Gi` |
@@ -99,8 +116,9 @@ The following table lists the main configuration parameters and default values.
 | `autoscaling.maxReplicas` | HPA maximum replicas | `10` |
 | `autoscaling.targetCPUUtilizationPercentage` | HPA CPU target | `80` |
 | `resources` | Container resource requests and limits | see `values.yaml` |
-| `livenessProbe.enabled` | Enable liveness probe (`/healthz`) | `true` |
-| `readinessProbe.enabled` | Enable readiness probe (`/healthz`) | `true` |
+| `livenessProbe.enabled` | Enable liveness probe (tcpSocket on HTTP port; does not check Redis) | `true` |
+| `readinessProbe.enabled` | Enable readiness probe (`/healthz`, includes Redis ping) | `true` |
+| `readinessProbe.path` | Readiness probe HTTP path | `/healthz` |
 
 ## Producer contract
 

--- a/charts/ocean-gateway/templates/NOTES.txt
+++ b/charts/ocean-gateway/templates/NOTES.txt
@@ -1,0 +1,37 @@
+Ocean Gateway has been deployed.
+
+  Release name : {{ .Release.Name }}
+  Namespace    : {{ .Release.Namespace }}
+  Image        : {{ include "ocean-gateway.image" . }}
+{{- if .Values.redis.enabled }}
+  Redis        : bundled ({{ include "ocean-gateway.redisHost" . }}:6379)
+{{- else if .Values.redis.existingSecret }}
+  Redis        : external (secret {{ .Values.redis.existingSecret }})
+{{- else }}
+  Redis        : {{ include "ocean-gateway.redisUrl" . }}
+{{- end }}
+
+The gateway is accepting live-event webhooks at:
+
+  POST http://{{ include "ocean-gateway.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/live-events/{liveEventsUUID}/integration/webhook
+
+Each accepted event (202) is written synchronously to the Redis stream:
+
+  {liveEventsUUID}/live-events/raw/event-stream
+
+Health check:
+
+  kubectl port-forward svc/{{ include "ocean-gateway.fullname" . }} {{ .Values.service.port }} -n {{ .Release.Namespace }}
+  curl http://localhost:{{ .Values.service.port }}/healthz
+
+Metrics (Prometheus):
+
+  curl http://localhost:{{ .Values.service.port }}/metrics
+
+Producer contract:
+  - 202 Accepted  → event is durably in the Redis stream
+  - 503            → Redis temporarily unavailable; producer must retry
+
+Consumer guidance:
+  Use XREADGROUP + XACK on the stream for at-least-once delivery.
+  See https://github.com/port-labs/ocean-gateway#consuming-the-streams

--- a/charts/ocean-gateway/templates/NOTES.txt
+++ b/charts/ocean-gateway/templates/NOTES.txt
@@ -13,7 +13,11 @@ Ocean Gateway has been deployed.
 
 The gateway is accepting live-event webhooks at:
 
+{{- if .Values.ingress.enabled }}
+  POST {{ include "ocean-gateway.publicBaseUrl" . }}/live-events/{liveEventsUUID}/integration/webhook
+{{- else }}
   POST http://{{ include "ocean-gateway.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/live-events/{liveEventsUUID}/integration/webhook
+{{- end }}
 
 Each accepted event (202) is written synchronously to the Redis stream:
 

--- a/charts/ocean-gateway/templates/NOTES.txt
+++ b/charts/ocean-gateway/templates/NOTES.txt
@@ -16,7 +16,7 @@ The gateway is accepting live-event webhooks at:
 {{- if .Values.ingress.enabled }}
   POST {{ include "ocean-gateway.publicBaseUrl" . }}/live-events/{liveEventsUUID}/<webhookSuffix>
 {{- else }}
-  POST http://{{ include "ocean-gateway.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/live-events/{liveEventsUUID}/integration/webhook
+  POST http://{{ include "ocean-gateway.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/live-events/{liveEventsUUID}/<webhookSuffix>
 {{- end }}
 
 Each accepted event (202) is written synchronously to the Redis stream:

--- a/charts/ocean-gateway/templates/NOTES.txt
+++ b/charts/ocean-gateway/templates/NOTES.txt
@@ -14,7 +14,7 @@ Ocean Gateway has been deployed.
 The gateway is accepting live-event webhooks at:
 
 {{- if .Values.ingress.enabled }}
-  POST {{ include "ocean-gateway.publicBaseUrl" . }}/live-events/{liveEventsUUID}/integration/webhook
+  POST {{ include "ocean-gateway.publicBaseUrl" . }}/live-events/{liveEventsUUID}/<webhookSuffix>
 {{- else }}
   POST http://{{ include "ocean-gateway.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/live-events/{liveEventsUUID}/integration/webhook
 {{- end }}

--- a/charts/ocean-gateway/templates/NOTES.txt
+++ b/charts/ocean-gateway/templates/NOTES.txt
@@ -35,7 +35,3 @@ Metrics (Prometheus):
 Producer contract:
   - 202 Accepted  → event is durably in the Redis stream
   - 503            → Redis temporarily unavailable; producer must retry
-
-Consumer guidance:
-  Use XREADGROUP + XACK on the stream for at-least-once delivery.
-  See https://github.com/port-labs/ocean-gateway#consuming-the-streams

--- a/charts/ocean-gateway/templates/_helpers.tpl
+++ b/charts/ocean-gateway/templates/_helpers.tpl
@@ -130,3 +130,21 @@ Image used by the wait-for-redis init container.
 {{- $tag := .Values.redis.image.tag | default "7.4.3-debian-12-r0" -}}
 {{- printf "%s/%s:%s" $registry $repository $tag -}}
 {{- end }}
+
+{{/*
+Ingress name.
+*/}}
+{{- define "ocean-gateway.ingressName" -}}
+{{- printf "%s-ingress" (include "ocean-gateway.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Public webhook base URL when Ingress is enabled (scheme + host).
+*/}}
+{{- define "ocean-gateway.publicBaseUrl" -}}
+{{- if .Values.ingress.tls -}}
+https://{{ required "ingress.host is required when ingress is enabled" .Values.ingress.host }}
+{{- else -}}
+http://{{ required "ingress.host is required when ingress is enabled" .Values.ingress.host }}
+{{- end -}}
+{{- end }}

--- a/charts/ocean-gateway/templates/_helpers.tpl
+++ b/charts/ocean-gateway/templates/_helpers.tpl
@@ -1,0 +1,132 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ocean-gateway.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this
+(by the DNS naming spec).
+*/}}
+{{- define "ocean-gateway.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ocean-gateway.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "ocean-gateway.labels" -}}
+helm.sh/chart: {{ include "ocean-gateway.chart" . }}
+{{ include "ocean-gateway.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- range $key, $value := .Values.extraLabels }}
+{{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels — used in matchLabels and service selectors.
+*/}}
+{{- define "ocean-gateway.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ocean-gateway.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Resolved container image (repository:tag, tag defaults to appVersion).
+*/}}
+{{- define "ocean-gateway.image" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion }}
+{{- printf "%s:%s" .Values.image.repository $tag }}
+{{- end }}
+
+{{/*
+ConfigMap name.
+*/}}
+{{- define "ocean-gateway.configMapName" -}}
+{{- printf "%s-config" (include "ocean-gateway.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Secret name (only created when redis.password is set).
+*/}}
+{{- define "ocean-gateway.secretName" -}}
+{{- printf "%s-secret" (include "ocean-gateway.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Bundled Redis master service hostname (Bitnami standalone).
+*/}}
+{{- define "ocean-gateway.redisHost" -}}
+{{- printf "%s-redis-master" .Release.Name }}
+{{- end }}
+
+{{/*
+Redis URL for the gateway connection.
+*/}}
+{{- define "ocean-gateway.redisUrl" -}}
+{{- if .Values.redis.enabled -}}
+{{- printf "%s:6379" (include "ocean-gateway.redisHost" .) -}}
+{{- else -}}
+{{- required "redis.url is required when redis.enabled is false and redis.existingSecret is not set" .Values.redis.url -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Redis password for the gateway connection.
+*/}}
+{{- define "ocean-gateway.redisPassword" -}}
+{{- if .Values.redis.enabled -}}
+{{- .Values.redis.auth.password -}}
+{{- else -}}
+{{- .Values.redis.password -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Whether the chart should create a gateway Redis Secret.
+*/}}
+{{- define "ocean-gateway.redisSecretCreate" -}}
+{{- if .Values.redis.existingSecret -}}
+false
+{{- else if .Values.redis.username -}}
+true
+{{- else if and .Values.redis.enabled .Values.redis.auth.enabled .Values.redis.auth.password -}}
+true
+{{- else if and (not .Values.redis.enabled) .Values.redis.password -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end }}
+
+{{/*
+Image used by the wait-for-redis init container.
+*/}}
+{{- define "ocean-gateway.redisWaitImage" -}}
+{{- $registry := .Values.redis.image.registry | default "docker.io" -}}
+{{- $repository := .Values.redis.image.repository | default "bitnami/redis" -}}
+{{- $tag := .Values.redis.image.tag | default "7.4.3-debian-12-r0" -}}
+{{- printf "%s/%s:%s" $registry $repository $tag -}}
+{{- end }}

--- a/charts/ocean-gateway/templates/_helpers.tpl
+++ b/charts/ocean-gateway/templates/_helpers.tpl
@@ -54,10 +54,21 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-Resolved container image (repository:tag, tag defaults to appVersion).
+ServiceAccount name for gateway pods.
+*/}}
+{{- define "ocean-gateway.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "ocean-gateway.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Resolved container image (repository:tag, tag defaults to latest).
 */}}
 {{- define "ocean-gateway.image" -}}
-{{- $tag := .Values.image.tag | default .Chart.AppVersion }}
+{{- $tag := .Values.image.tag | default "latest" }}
 {{- printf "%s:%s" .Values.image.repository $tag }}
 {{- end }}
 
@@ -80,6 +91,36 @@ Bundled Redis master service hostname (Bitnami standalone).
 */}}
 {{- define "ocean-gateway.redisHost" -}}
 {{- printf "%s-redis-master" .Release.Name }}
+{{- end }}
+
+{{/*
+Fail fast on incompatible Redis value combinations.
+*/}}
+{{- define "ocean-gateway.validateValues" -}}
+{{- if and .Values.redis.enabled .Values.redis.existingSecret -}}
+{{- fail "redis.enabled and redis.existingSecret are mutually exclusive" -}}
+{{- end -}}
+{{- if and .Values.redis.enabled (ne .Values.redis.url "") -}}
+{{- fail "redis.url must not be set when redis.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.redis.enabled (ne .Values.redis.password "") -}}
+{{- fail "redis.password must not be set when redis.enabled=true; use redis.auth.password" -}}
+{{- end -}}
+{{- if and .Values.redis.enabled .Values.redis.tls.enabled -}}
+{{- fail "redis.tls.enabled must not be set when redis.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.redis.existingSecret (ne .Values.redis.url "") -}}
+{{- fail "redis.url must not be set when redis.existingSecret is set" -}}
+{{- end -}}
+{{- if and .Values.redis.existingSecret (ne .Values.redis.password "") -}}
+{{- fail "redis.password must not be set when redis.existingSecret is set" -}}
+{{- end -}}
+{{- if and .Values.redis.existingSecret (ne .Values.redis.username "") -}}
+{{- fail "redis.username must not be set when redis.existingSecret is set" -}}
+{{- end -}}
+{{- if and .Values.redis.existingSecret .Values.redis.tls.enabled -}}
+{{- fail "redis.tls.enabled must not be set when redis.existingSecret is set" -}}
+{{- end -}}
 {{- end }}
 
 {{/*
@@ -122,12 +163,23 @@ false
 {{- end }}
 
 {{/*
+Checksum for Redis credentials — changes trigger a rolling pod restart.
+*/}}
+{{- define "ocean-gateway.redisCredentialsChecksum" -}}
+{{- if eq (include "ocean-gateway.redisSecretCreate" .) "true" -}}
+{{- include (print $.Template.BasePath "/secret.yaml") . | sha256sum -}}
+{{- else if .Values.redis.existingSecret -}}
+{{- printf "%s|%s" .Values.redis.existingSecret (.Values.redis.credentialsRevision | default "") | sha256sum -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Image used by the wait-for-redis init container.
 */}}
 {{- define "ocean-gateway.redisWaitImage" -}}
 {{- $registry := .Values.redis.image.registry | default "docker.io" -}}
-{{- $repository := .Values.redis.image.repository | default "bitnami/redis" -}}
-{{- $tag := .Values.redis.image.tag | default "7.4.3-debian-12-r0" -}}
+{{- $repository := .Values.redis.image.repository | default "bitnamisecure/redis" -}}
+{{- $tag := .Values.redis.image.tag | default "latest" -}}
 {{- printf "%s/%s:%s" $registry $repository $tag -}}
 {{- end }}
 

--- a/charts/ocean-gateway/templates/_helpers.tpl
+++ b/charts/ocean-gateway/templates/_helpers.tpl
@@ -106,6 +106,9 @@ Fail fast on incompatible Redis value combinations.
 {{- if and .Values.redis.enabled (ne .Values.redis.password "") -}}
 {{- fail "redis.password must not be set when redis.enabled=true; use redis.auth.password" -}}
 {{- end -}}
+{{- if and .Values.redis.enabled (ne .Values.redis.username "") -}}
+{{- fail "redis.username must not be set when redis.enabled=true" -}}
+{{- end -}}
 {{- if and .Values.redis.enabled .Values.redis.tls.enabled -}}
 {{- fail "redis.tls.enabled must not be set when redis.enabled=true" -}}
 {{- end -}}

--- a/charts/ocean-gateway/templates/configmap.yaml
+++ b/charts/ocean-gateway/templates/configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "ocean-gateway.configMapName" . }}
+  labels:
+    {{- include "ocean-gateway.labels" . | nindent 4 }}
+data:
+  LISTEN_ADDR: ":{{ .Values.service.port }}"
+  {{- if not .Values.redis.existingSecret }}
+  REDIS_OCEAN_GATEWAY_URL: {{ include "ocean-gateway.redisUrl" . | quote }}
+  {{- end }}
+  REDIS_DB: {{ .Values.redis.db | toString | quote }}
+  REDIS_POOL_SIZE: {{ .Values.redis.poolSize | toString | quote }}
+  REDIS_STREAM_MAXLEN: {{ .Values.stream.maxLen | toString | quote }}
+  EVENT_TTL: {{ .Values.stream.eventTTL | quote }}
+  STREAM_TTL: {{ .Values.stream.streamTTL | quote }}
+  WRITE_MAX_RETRIES: {{ .Values.write.maxRetries | toString | quote }}
+  WRITE_BACKOFF_BASE: {{ .Values.write.backoffBase | quote }}

--- a/charts/ocean-gateway/templates/configmap.yaml
+++ b/charts/ocean-gateway/templates/configmap.yaml
@@ -7,7 +7,8 @@ metadata:
 data:
   LISTEN_ADDR: ":{{ .Values.service.port }}"
   {{- if not .Values.redis.existingSecret }}
-  REDIS_OCEAN_GATEWAY_URL: {{ include "ocean-gateway.redisUrl" . | quote }}
+  REDIS_OCEAN_LIVE_EVENTS_URL: {{ include "ocean-gateway.redisUrl" . | quote }}
+  REDIS_OCEAN_LIVE_EVENTS_ENABLE_TLS: {{ .Values.redis.tls.enabled | toString | quote }}
   {{- end }}
   REDIS_DB: {{ .Values.redis.db | toString | quote }}
   REDIS_POOL_SIZE: {{ .Values.redis.poolSize | toString | quote }}

--- a/charts/ocean-gateway/templates/deployment.yaml
+++ b/charts/ocean-gateway/templates/deployment.yaml
@@ -1,0 +1,133 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ocean-gateway.fullname" . }}
+  labels:
+    {{- include "ocean-gateway.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "ocean-gateway.selectorLabels" . | nindent 6 }}
+  # RollingUpdate: the gateway is stateless so zero-downtime deploys are safe.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      annotations:
+        # Restart pods when the ConfigMap changes.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "ocean-gateway.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.redis.enabled }}
+      initContainers:
+        - name: wait-for-redis
+          image: {{ include "ocean-gateway.redisWaitImage" . }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - -ec
+            - |
+              until redis-cli -h {{ include "ocean-gateway.redisHost" . }} -p 6379 \
+                {{- if and .Values.redis.auth.enabled .Values.redis.auth.password }}
+                -a "${REDIS_PASSWORD}" \
+                {{- end }}
+                ping | grep -q PONG; do
+                echo "Waiting for Redis {{ include "ocean-gateway.redisHost" . }} to be ready..."
+                sleep 2
+              done
+          {{- if and .Values.redis.auth.enabled .Values.redis.auth.password }}
+          env:
+            - name: REDIS_PASSWORD
+              value: {{ .Values.redis.auth.password | quote }}
+          {{- end }}
+      {{- end }}
+      containers:
+        - name: {{ include "ocean-gateway.name" . }}
+          image: {{ include "ocean-gateway.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "ocean-gateway.configMapName" . }}
+            {{- if .Values.redis.existingSecret }}
+            - secretRef:
+                name: {{ .Values.redis.existingSecret }}
+            {{- else if eq (include "ocean-gateway.redisSecretCreate" .) "true" }}
+            - secretRef:
+                name: {{ include "ocean-gateway.secretName" . }}
+            {{- end }}
+          {{- if .Values.extraEnv }}
+          env:
+            {{- tpl (toYaml .Values.extraEnv) . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.extraVolumeMounts }}
+          volumeMounts:
+            {{- tpl (toYaml .Values.extraVolumeMounts) . | nindent 12 }}
+          {{- end }}
+      {{- if .Values.extraVolumes }}
+      volumes:
+        {{- tpl (toYaml .Values.extraVolumes) . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/ocean-gateway/templates/deployment.yaml
+++ b/charts/ocean-gateway/templates/deployment.yaml
@@ -22,6 +22,10 @@ spec:
       annotations:
         # Restart pods when the ConfigMap changes.
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with include "ocean-gateway.redisCredentialsChecksum" . }}
+        # Restart pods when chart-managed Redis credentials or credentialsRevision change.
+        checksum/redis-credentials: {{ . }}
+        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -31,6 +35,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      serviceAccountName: {{ include "ocean-gateway.serviceAccountName" . }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -44,6 +49,10 @@ spec:
         - name: wait-for-redis
           image: {{ include "ocean-gateway.redisWaitImage" . }}
           imagePullPolicy: IfNotPresent
+          {{- with .Values.initContainer.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command:
             - /bin/bash
             - -ec
@@ -59,8 +68,13 @@ spec:
           {{- if and .Values.redis.auth.enabled .Values.redis.auth.password }}
           env:
             - name: REDIS_PASSWORD
-              value: {{ .Values.redis.auth.password | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.redis.existingSecret | default (include "ocean-gateway.secretName" .) }}
+                  key: REDIS_OCEAN_LIVE_EVENTS_PASSWORD
           {{- end }}
+          resources:
+            {{- toYaml .Values.initContainer.resources | nindent 12 }}
       {{- end }}
       containers:
         - name: {{ include "ocean-gateway.name" . }}
@@ -90,8 +104,7 @@ spec:
           {{- end }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
-            httpGet:
-              path: /healthz
+            tcpSocket:
               port: http
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
@@ -101,7 +114,7 @@ spec:
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: {{ .Values.readinessProbe.path }}
               port: http
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}

--- a/charts/ocean-gateway/templates/hpa.yaml
+++ b/charts/ocean-gateway/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "ocean-gateway.fullname" . }}
+  labels:
+    {{- include "ocean-gateway.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "ocean-gateway.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/ocean-gateway/templates/ingress.yaml
+++ b/charts/ocean-gateway/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress }}
+{{- if (eq .Values.ingress.enabled true) }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "ocean-gateway.ingressName" . }}
+  labels:
+    {{- include "ocean-gateway.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.ingress.annotations }}
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+  {{- end }}
+  rules:
+    - {{- if .Values.ingress.host }}
+      host: {{ .Values.ingress.host }}
+      {{- end }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "ocean-gateway.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/ocean-gateway/templates/ingress.yaml
+++ b/charts/ocean-gateway/templates/ingress.yaml
@@ -1,23 +1,22 @@
 {{- if .Values.ingress }}
 {{- if (eq .Values.ingress.enabled true) }}
+{{- $host := required "ingress.host is required when ingress is enabled" .Values.ingress.host }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "ocean-gateway.ingressName" . }}
   labels:
     {{- include "ocean-gateway.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
   annotations:
-    {{- if .Values.ingress.annotations }}
-    {{- toYaml .Values.ingress.annotations | nindent 4 }}
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className | quote }}
   {{- end }}
   rules:
-    - {{- if .Values.ingress.host }}
-      host: {{ .Values.ingress.host }}
-      {{- end }}
+    - host: {{ $host }}
       http:
         paths:
           - path: {{ .Values.ingress.path }}

--- a/charts/ocean-gateway/templates/secret.yaml
+++ b/charts/ocean-gateway/templates/secret.yaml
@@ -1,0 +1,17 @@
+{{- if eq (include "ocean-gateway.redisSecretCreate" .) "true" }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ocean-gateway.secretName" . }}
+  labels:
+    {{- include "ocean-gateway.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- $password := include "ocean-gateway.redisPassword" . }}
+  {{- if $password }}
+  REDIS_OCEAN_GATEWAY_PASSWORD: {{ $password | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.redis.username }}
+  REDIS_OCEAN_GATEWAY_USERNAME: {{ .Values.redis.username | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/ocean-gateway/templates/secret.yaml
+++ b/charts/ocean-gateway/templates/secret.yaml
@@ -9,9 +9,9 @@ type: Opaque
 data:
   {{- $password := include "ocean-gateway.redisPassword" . }}
   {{- if $password }}
-  REDIS_OCEAN_GATEWAY_PASSWORD: {{ $password | b64enc | quote }}
+  REDIS_OCEAN_LIVE_EVENTS_PASSWORD: {{ $password | b64enc | quote }}
   {{- end }}
   {{- if .Values.redis.username }}
-  REDIS_OCEAN_GATEWAY_USERNAME: {{ .Values.redis.username | b64enc | quote }}
+  REDIS_OCEAN_LIVE_EVENTS_USERNAME: {{ .Values.redis.username | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/charts/ocean-gateway/templates/service.yaml
+++ b/charts/ocean-gateway/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ocean-gateway.fullname" . }}
+  labels:
+    {{- include "ocean-gateway.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      protocol: TCP
+      port: {{ .Values.service.port }}
+      targetPort: http
+  selector:
+    {{- include "ocean-gateway.selectorLabels" . | nindent 4 }}

--- a/charts/ocean-gateway/templates/serviceaccount.yaml
+++ b/charts/ocean-gateway/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ocean-gateway.serviceAccountName" . }}
+  labels:
+    {{- include "ocean-gateway.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/ocean-gateway/templates/validate.yaml
+++ b/charts/ocean-gateway/templates/validate.yaml
@@ -1,0 +1,1 @@
+{{- include "ocean-gateway.validateValues" . -}}

--- a/charts/ocean-gateway/values.yaml
+++ b/charts/ocean-gateway/values.yaml
@@ -1,0 +1,128 @@
+# ocean-gateway Helm chart values.
+#
+# The gateway writes each incoming webhook straight to a Redis stream before
+# returning 202. It holds no in-memory buffer, so it is stateless and scales
+# horizontally with no coordination between replicas.
+#
+# External Redis: set redis.url (or redis.existingSecret).
+# No external Redis: set redis.enabled=true to deploy a bundled Bitnami Redis.
+
+nameOverride: ""
+fullnameOverride: ""
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/port-labs/ocean-gateway
+  pullPolicy: IfNotPresent
+  # Defaults to Chart.appVersion when empty.
+  tag: ""
+
+imagePullSecrets: []
+
+podAnnotations: {}
+podLabels: {}
+podSecurityContext: {}
+containerSecurityContext: {}
+
+extraLabels: {}
+extraEnv: []
+extraVolumes: []
+extraVolumeMounts: []
+
+# ── Redis ─────────────────────────────────────────────────────────────────────
+redis:
+  # Deploy a bundled Redis instance (Bitnami subchart). When true, redis.url is
+  # auto-wired to the subchart service and redis.auth.password is used for the
+  # gateway connection unless redis.existingSecret is set.
+  enabled: false
+
+  # External Redis URL, e.g. "redis:6379". Required when enabled=false and
+  # existingSecret is not set.
+  url: ""
+  # Optional Redis username and password for external Redis. Stored in a Secret when set.
+  username: ""
+  password: ""
+  # Name of a pre-existing Secret to use instead of chart-managed values.
+  # The secret may contain any of: REDIS_OCEAN_GATEWAY_URL, REDIS_OCEAN_GATEWAY_USERNAME, REDIS_OCEAN_GATEWAY_PASSWORD.
+  # When set, redis.url/username/password are ignored and no Secret is created.
+  existingSecret: ""
+  db: 0
+  # Connection pool size. 0 = go-redis default (10 × GOMAXPROCS).
+  # Raise this if gateway_inflight_requests is often near the pool ceiling.
+  poolSize: 0
+
+  # ── Bundled Redis (Bitnami subchart) settings ───────────────────────────────
+  # Only applied when redis.enabled=true.
+  architecture: standalone
+  auth:
+    enabled: true
+    password: "changeme"
+  master:
+    persistence:
+      enabled: true
+      size: 8Gi
+
+# ── Stream retention ──────────────────────────────────────────────────────────
+stream:
+  # Trim stream entries older than this via XADD MINID. 0 = no age-based trim.
+  eventTTL: "1h"
+  # Refresh stream key EXPIRE on every write; idle streams are deleted after
+  # this TTL. 0 = no expiry. Set longer than eventTTL if consumers may lag.
+  streamTTL: "1h"
+  # Approx MAXLEN per stream (size-based trim). Ignored when eventTTL > 0.
+  # 0 = uncapped.
+  maxLen: 0
+
+# ── Write retry policy ────────────────────────────────────────────────────────
+write:
+  # Per-request XADD retries before returning 503 to the producer.
+  maxRetries: 2
+  # Initial retry backoff (doubles on each attempt).
+  backoffBase: "50ms"
+
+# ── Service ───────────────────────────────────────────────────────────────────
+service:
+  type: ClusterIP
+  port: 8080
+  annotations: {}
+
+# ── Resources ─────────────────────────────────────────────────────────────────
+resources:
+  requests:
+    memory: "128Mi"
+    cpu: "100m"
+  limits:
+    memory: "256Mi"
+    cpu: "500m"
+
+# ── Health probes ─────────────────────────────────────────────────────────────
+# /healthz pings Redis on every call — 200 when healthy, 503 when degraded.
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 3
+  successThreshold: 1
+
+# ── Horizontal Pod Autoscaler ─────────────────────────────────────────────────
+# The gateway is fully stateless; scale freely without coordination.
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# ── Scheduling ────────────────────────────────────────────────────────────────
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/charts/ocean-gateway/values.yaml
+++ b/charts/ocean-gateway/values.yaml
@@ -87,6 +87,23 @@ service:
   port: 8080
   annotations: {}
 
+# ── Ingress ───────────────────────────────────────────────────────────────────
+# Expose the gateway to external webhook providers. Use path `/` (Prefix) so
+# all /live-events/{uuid}/integration/... routes reach the gateway.
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  host: null
+  path: /
+  pathType: Prefix
+  tls: []
+  # Example
+  # tls:
+  #   - secretName: ocean-gateway-tls
+  #     hosts:
+  #       - gateway.example.com
+
 # ── Resources ─────────────────────────────────────────────────────────────────
 resources:
   requests:

--- a/charts/ocean-gateway/values.yaml
+++ b/charts/ocean-gateway/values.yaml
@@ -14,16 +14,41 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/port-labs/ocean-gateway
-  pullPolicy: IfNotPresent
-  # Defaults to Chart.appVersion when empty.
-  tag: ""
+  pullPolicy: Always
+  # Defaults to "latest" when empty.
+  tag: "latest"
 
 imagePullSecrets: []
+
+serviceAccount:
+  # Opt in to a dedicated ServiceAccount
+  create: false
+  annotations: {}
+  name: ""
 
 podAnnotations: {}
 podLabels: {}
 podSecurityContext: {}
 containerSecurityContext: {}
+
+# wait-for-redis init container (only when redis.enabled=true)
+initContainer:
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    runAsNonRoot: true
+    runAsUser: 1001
+    seccompProfile:
+      type: RuntimeDefault
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi
 
 extraLabels: {}
 extraEnv: []
@@ -44,9 +69,15 @@ redis:
   username: ""
   password: ""
   # Name of a pre-existing Secret to use instead of chart-managed values.
-  # The secret may contain any of: REDIS_OCEAN_GATEWAY_URL, REDIS_OCEAN_GATEWAY_USERNAME, REDIS_OCEAN_GATEWAY_PASSWORD.
-  # When set, redis.url/username/password are ignored and no Secret is created.
+  # The secret may contain any of: REDIS_OCEAN_LIVE_EVENTS_URL, REDIS_OCEAN_LIVE_EVENTS_USERNAME,
+  # REDIS_OCEAN_LIVE_EVENTS_PASSWORD, REDIS_OCEAN_LIVE_EVENTS_ENABLE_TLS.
+  # When set, redis.url/username/password/tls.enabled are ignored and no Secret is created.
   existingSecret: ""
+  # Bump after rotating redis.existingSecret out-of-band to trigger a pod rollout.
+  credentialsRevision: ""
+  # Enable TLS for external/managed Redis (in-transit encryption). Ignored when existingSecret is set.
+  tls:
+    enabled: false
   db: 0
   # Connection pool size. 0 = go-redis default (10 × GOMAXPROCS).
   # Raise this if gateway_inflight_requests is often near the pool ceiling.
@@ -54,6 +85,14 @@ redis:
 
   # ── Bundled Redis (Bitnami subchart) settings ───────────────────────────────
   # Only applied when redis.enabled=true.
+  # Bitnami moved maintained images to bitnamisecure/*; defaults match port-ocean.
+  global:
+    security:
+      allowInsecureImages: true
+  image:
+    registry: docker.io
+    repository: bitnamisecure/redis
+    tag: latest
   architecture: standalone
   auth:
     enabled: true
@@ -114,7 +153,8 @@ resources:
     cpu: "500m"
 
 # ── Health probes ─────────────────────────────────────────────────────────────
-# /healthz pings Redis on every call — 200 when healthy, 503 when degraded.
+# Liveness: tcpSocket on the HTTP port — process listening, no Redis check.
+# Readiness: GET /healthz — pings Redis; 503 removes the pod from Service traffic.
 livenessProbe:
   enabled: true
   initialDelaySeconds: 5
@@ -124,6 +164,7 @@ livenessProbe:
 
 readinessProbe:
   enabled: true
+  path: /healthz
   initialDelaySeconds: 5
   periodSeconds: 5
   timeoutSeconds: 3


### PR DESCRIPTION
# Description

- Add a new `charts/ocean-gateway` Helm chart.

- Chart supports bundled Redis (Bitnami subchart) or external Redis, optional Ingress for external webhook providers, HPA, health probes, and stream retention/write-retry configuration.

- Add CI workflow to lint and template the chart (external Redis, bundled Redis, ingress, existing secret, and validation that `redis.url` is required when Redis is not bundled).

**Basically copied the charts from ocean-gateway repo to this helm-charts repo.**

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

