### PR TITLE
Apply container defaults to chart-managed init containers

### DIFF
--- a/charts/port-ocean/Chart.yaml
+++ b/charts/port-ocean/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-ocean
 description: A Helm chart for Port Ocean integrations
 type: application
-version: 0.21.0
+version: 0.21.1
 appVersion: "0.1.0"
 home: https://getport.io/
 sources:

--- a/charts/port-ocean/Chart.yaml
+++ b/charts/port-ocean/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-ocean
 description: A Helm chart for Port Ocean integrations
 type: application
-version: 0.21.1
+version: 0.22.0
 appVersion: "0.1.0"
 home: https://getport.io/
 sources:

--- a/charts/port-ocean/templates/_helpers.tpl
+++ b/charts/port-ocean/templates/_helpers.tpl
@@ -282,3 +282,18 @@ Get self signed cert secret name
     name: {{ . }}
 {{- end }}
 {{- end }}
+
+{{/*
+Default container settings for chart-managed init containers (pull policy, security context, resources).
+*/}}
+{{- define "port-ocean.initContainer.containerDefaults" -}}
+imagePullPolicy: {{ .Values.imagePullPolicy }}
+securityContext:
+  {{- if .Values.containerSecurityContext }}
+  {{- toYaml .Values.containerSecurityContext | nindent 2 }}
+  {{- end }}
+resources:
+  {{- if .Values.resources }}
+  {{- toYaml .Values.resources | nindent 2 }}
+  {{- end }}
+{{- end -}}

--- a/charts/port-ocean/templates/cron-job/cron.yaml
+++ b/charts/port-ocean/templates/cron-job/cron.yaml
@@ -62,6 +62,7 @@ spec:
             {{- if .Values.postgresql.enabled }}
             - name: wait-for-postgresql
               image: {{ .Values.postgresql.image }}
+              {{- include "port-ocean.initContainer.containerDefaults" . | nindent 14 }}
               command:
                 - sh
                 - -c
@@ -74,6 +75,7 @@ spec:
             {{- end }}
             - name: terminate-old-resync-jobs
               image: {{ .Values.workload.cron.kubectlImage }}
+              {{- include "port-ocean.initContainer.containerDefaults" . | nindent 14 }}
               env:
                 - name: JOB_NAME
                   valueFrom:

--- a/charts/port-ocean/templates/cron-job/incremental-cron.yaml
+++ b/charts/port-ocean/templates/cron-job/incremental-cron.yaml
@@ -60,6 +60,7 @@ spec:
             {{- if .Values.postgresql.enabled }}
             - name: wait-for-postgresql
               image: {{ .Values.postgresql.image }}
+              {{- include "port-ocean.initContainer.containerDefaults" . | nindent 14 }}
               command:
                 - sh
                 - -c

--- a/charts/port-ocean/templates/cron-job/installation-resync-job.yml
+++ b/charts/port-ocean/templates/cron-job/installation-resync-job.yml
@@ -48,16 +48,8 @@ spec:
       containers:
         - name: kubectl
           image: {{ .Values.workload.cron.kubectlImage }}
-          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          {{- include "port-ocean.initContainer.containerDefaults" . | nindent 10 }}
           command: [ "sh", "-c" ]
-          securityContext:
-            {{- if .Values.containerSecurityContext }}
-            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
-            {{- end }}
-          resources:
-            {{- if .Values.resources }}
-            {{- toYaml .Values.resources | nindent 12 }}
-            {{- end }}
           env:
             - name: TOKEN
               valueFrom:

--- a/charts/port-ocean/templates/deployment-live-events.yaml
+++ b/charts/port-ocean/templates/deployment-live-events.yaml
@@ -53,6 +53,7 @@ spec:
         {{- if .Values.postgresql.enabled }}
         - name: wait-for-postgresql
           image: {{ .Values.postgresql.image }}
+          {{- include "port-ocean.initContainer.containerDefaults" . | nindent 10 }}
           command:
             - sh
             - -c

--- a/charts/port-ocean/templates/deployment.yaml
+++ b/charts/port-ocean/templates/deployment.yaml
@@ -46,6 +46,7 @@ spec:
         {{- if .Values.postgresql.enabled }}
         - name: wait-for-postgresql
           image: {{ .Values.postgresql.image }}
+          {{- include "port-ocean.initContainer.containerDefaults" . | nindent 10 }}
           command:
             - sh
             - -c


### PR DESCRIPTION
## Summary

- Add shared container defaults (`imagePullPolicy`, `containerSecurityContext`, `resources`) to all chart-managed init containers.
- Fixes CronJob resync pods being rejected by admission controllers (e.g. Gatekeeper `psp-allow-privilege-escalation-container`) on `terminate-old-resync-jobs`.
- Bump `port-ocean` chart version to `0.22.0`.

Follow-up to #302 / [PORT-17808](https://getport.atlassian.net/browse/PORT-17808).

## What

#302 fixed the **init-sync Helm hook** pod (`installation-resync-job.yml`). Customers could deploy the CronJob, but the **spawned resync Job** still failed because chart-defined init containers were missing per-container configuration.

Most notably, `terminate-old-resync-jobs` in `cron.yaml` had no `securityContext`, so policies requiring `allowPrivilegeEscalation: false` on every container blocked the pod:

```
admission webhook "validation.gatekeeper.sh" denied the request:
[psp-allow-privilege-escalation-container] Privilege escalation container is not allowed: terminate-old-resync-jobs
```

`allowPrivilegeEscalation` is a **container-level** field — pod-level `podSecurityContext` does not satisfy this policy.

## Why

Enterprise clusters commonly enforce per-container security context, image pull policy, and resource requests/limits. Chart-managed init containers were rendered with only an `image` and `command`, while main containers already inherited these values from chart config.

## How

Introduced a shared Helm helper, `port-ocean.initContainer.containerDefaults`, that applies:

| Field | Source |
|---|---|
| `imagePullPolicy` | `.Values.imagePullPolicy` |
| `securityContext` | `.Values.containerSecurityContext` |
| `resources` | `.Values.resources` |

Applied to chart-managed init containers in:

- `cron.yaml` — `terminate-old-resync-jobs`, `wait-for-postgresql`
- `incremental-cron.yaml` — `wait-for-postgresql`
- `deployment.yaml` — `wait-for-postgresql`
- `deployment-live-events.yaml` — `wait-for-postgresql`
- `installation-resync-job.yml` — `kubectl` (refactored to use the same helper)

**Not covered:** `extraInitContainers` and `workload.cron.extraContainers` remain user-supplied YAML; callers must configure security context on those themselves.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

## Customer configuration

Customers with strict admission policies should ensure values include e.g.:

```yaml
containerSecurityContext:
  allowPrivilegeEscalation: false
  runAsNonRoot: true

imagePullSecrets:
  - name: <private-registry-secret>
```

Pod-level settings (`imagePullSecrets`, `podSecurityContext`, annotations, scheduling) were already present on the cron resync pod; this PR fills the per-container gap on init containers.


[PORT-17808]: https://getport.atlassian.net/browse/PORT-17808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ