### PR TITLE
Add incremental sync configuration to ConfigMap

### DIFF
--- a/charts/port-ocean/Chart.yaml
+++ b/charts/port-ocean/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-ocean
 description: A Helm chart for Port Ocean integrations
 type: application
-version: 0.23.0
+version: 0.23.1
 appVersion: "0.1.0"
 home: https://getport.io/
 sources:

--- a/charts/port-ocean/templates/configmap.yaml
+++ b/charts/port-ocean/templates/configmap.yaml
@@ -45,6 +45,7 @@ data:
   OCEAN__PROCESSING_MODE: {{ .Values.processingMode | default "dsp" | quote }}
   OCEAN__STREAMING__ENABLED: "{{ .Values.streamingEnabled | default false }}"
   OCEAN__ACTIONS_PROCESSOR__ENABLED: "{{ .Values.actionsProcessor.enabled | default false }}"
+  OCEAN__INTEGRATION__INCREMENTAL_SYNC_ENABLED: "{{ .Values.incrementalSync.enabled | default false }}"
   {{- if .Values.actionsProcessor.extraConfig }}
   {{- range $key, $value := .Values.actionsProcessor.extraConfig }}
   OCEAN__ACTIONS_PROCESSOR__{{ $key | snakecase | upper }}: {{ $value | quote }}

--- a/charts/port-ocean/tests/configmap-incremental-sync_test.yaml
+++ b/charts/port-ocean/tests/configmap-incremental-sync_test.yaml
@@ -1,0 +1,21 @@
+suite: Main ConfigMap incremental sync
+templates:
+  - templates/configmap.yaml
+tests:
+  - it: sets incremental sync enabled to false by default
+    values:
+      - values/single.yaml
+    asserts:
+      - equal:
+          path: data.OCEAN__INTEGRATION__INCREMENTAL_SYNC_ENABLED
+          value: "false"
+
+  - it: sets incremental sync enabled when values enable it
+    values:
+      - values/single.yaml
+    set:
+      incrementalSync.enabled: true
+    asserts:
+      - equal:
+          path: data.OCEAN__INTEGRATION__INCREMENTAL_SYNC_ENABLED
+          value: "true"


### PR DESCRIPTION
# Description
Expose `incrementalSync.enabled` on the main ocean ConfigMap so the long-running pod can reconcile `incrementalSyncEnabled` with Port (same pattern as actions processing). Interval stays on the CronJob schedule / appSpec, not this ConfigMap.

## Type of change

Please leave one option from the following and delete the rest:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

