### PR TITLE
Add deployment annotations to port-ocean

### DIFF
--- a/charts/port-ocean/Chart.yaml
+++ b/charts/port-ocean/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-ocean
 description: A Helm chart for Port Ocean integrations
 type: application
-version: 0.23.1
+version: 0.23.2
 appVersion: "0.1.0"
 home: https://getport.io/
 sources:

--- a/charts/port-ocean/Chart.yaml
+++ b/charts/port-ocean/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-ocean
 description: A Helm chart for Port Ocean integrations
 type: application
-version: 0.23.0
+version: 0.23.1
 appVersion: "0.1.0"
 home: https://getport.io/
 sources:

--- a/charts/port-ocean/templates/deployment.yaml
+++ b/charts/port-ocean/templates/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "port-ocean.deploymentName" . }}
   labels:
     {{- include "port-ocean.labels" . | nindent 4 }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   strategy:
     type: {{ .Values.workload.deployment.rolloutStrategy | default "Recreate" }}

--- a/charts/port-ocean/tests/main-deployment_test.yaml
+++ b/charts/port-ocean/tests/main-deployment_test.yaml
@@ -12,6 +12,14 @@ tests:
           path: metadata.name
           value: ocean-github-test-id-deployment
 
+  - it: renders deployment annotations
+    values:
+      - values/deployment-annotations.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/monitoring"]
+          value: enabled
+
   - it: renders for split workers
     values:
       - values/split.yaml

--- a/charts/port-ocean/tests/values/deployment-annotations.yaml
+++ b/charts/port-ocean/tests/values/deployment-annotations.yaml
@@ -1,0 +1,9 @@
+port:
+  clientId: test
+  clientSecret: test
+integration:
+  type: github
+  identifier: test-id
+  version: 0.1.0
+deploymentAnnotations:
+  example.com/monitoring: enabled

--- a/charts/port-ocean/values.yaml
+++ b/charts/port-ocean/values.yaml
@@ -9,6 +9,7 @@ port:
   baseUrl: https://api.getport.io
   ingestUrl: https://ingest.getport.io
 
+deploymentAnnotations: { }
 podAnnotations: { }
 
 podServiceAccount:


### PR DESCRIPTION
## Summary
- expose `deploymentAnnotations` for the port-ocean Deployment resource
- add focused rendering coverage for deployment annotations
- fixes [PORT-18270](https://getport.atlassian.net/browse/PORT-18270)

Port task: https://app.getport.io/taskEntity?identifier=task_tj51qr

## Test plan
- [x] Rendered the chart with deployment annotations and validated Kubernetes manifests with `kubectl apply --dry-run=client`
- [ ] CI helm-unittest (the local Helm installation has no unittest plugin)

Made with [Cursor](https://cursor.com)

[PORT-18270]: https://getport.atlassian.net/browse/PORT-18270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ