### PR TITLE
Fix extraLabels boolean values rendering as non-string Kubernetes labels

### DIFF
--- a/charts/port-ocean/Chart.yaml
+++ b/charts/port-ocean/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-ocean
 description: A Helm chart for Port Ocean integrations
 type: application
-version: 0.23.2
+version: 0.23.3
 appVersion: "0.1.0"
 home: https://getport.io/
 sources:

--- a/charts/port-ocean/templates/_helpers.tpl
+++ b/charts/port-ocean/templates/_helpers.tpl
@@ -41,7 +41,7 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- range $key, $value := .Values.extraLabels }}
-{{$key}}: {{ $value }}
+{{$key}}: {{ $value | quote }}
 {{- end }}
 {{- end }}
 
@@ -57,7 +57,7 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- range $key, $value := .Values.extraLabels }}
-{{$key}}: {{ $value }}
+{{$key}}: {{ $value | quote }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -74,7 +74,7 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- range $key, $value := .Values.extraLabels }}
-{{$key}}: {{ $value }}
+{{$key}}: {{ $value | quote }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Summary

- Quote `extraLabels` values in label helpers so they always render as strings in Kubernetes manifests.
- Bump `port-ocean` chart version to `0.23.3`.

## What

`extraLabels` values were rendered without quoting in `port-ocean.labels` and related helpers:

```yaml
{{ $key }}: {{ $value }}
```

For labels like Istio sidecar injection, this produced:

```yaml
sidecar.istio.io/inject: false
```

YAML/JSON parsers treat unquoted `false` as a **boolean**, but Kubernetes label values must be **strings**. This caused apply failures such as:

```
json: cannot unmarshal bool into Go struct field ObjectMeta.metadata.labels of type string
```

## Why

A customer reported being unable to apply labels via `extraLabels`, e.g.:

```yaml
extraLabels:
  sidecar.istio.io/inject: "false"
```

Even when the value is a string in `values.yaml`, the rendered manifest omitted quotes, so the API still received a boolean.

## How

Added `| quote` to `extraLabels` value rendering in all three helpers in `_helpers.tpl`:

- `port-ocean.labels`
- `port-ocean.liveEvents.labels`
- `port-ocean.actionsProcessor.labels`

This matches the existing pattern used for `app.kubernetes.io/version`.

Rendered output is now:

```yaml
sidecar.istio.io/inject: "false"
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

## Test plan

- [x] Render with boolean-like `extraLabels` and verify quoted output:

```bash
cd charts/port-ocean
helm template test . \
  --set port.clientId=test \
  --set port.clientSecret=test \
  --set-json 'extraLabels={"sidecar.istio.io/inject":"false","team":"platform"}' \
  --show-only templates/cron-job/installation-resync-job.yml | rg 'sidecar.istio.io/inject'
# expect: sidecar.istio.io/inject: "false"
```

- [ ] `helm upgrade --install` with customer `extraLabels` values in a cluster
- [ ] Confirm manifests apply without label type errors