### PR TITLE
fix: trigger incremental sync job from installation resync hook

### DIFF
--- a/charts/port-ocean/Chart.yaml
+++ b/charts/port-ocean/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-ocean
 description: A Helm chart for Port Ocean integrations
 type: application
-version: 0.23.3
+version: 0.23.4
 appVersion: "0.1.0"
 home: https://getport.io/
 sources:

--- a/charts/port-ocean/templates/cron-job/installation-resync-job.yml
+++ b/charts/port-ocean/templates/cron-job/installation-resync-job.yml
@@ -1,6 +1,8 @@
 {{- $resyncOnInstall := ternary .Values.workload.cron.resyncOnInstall true (hasKey .Values.workload.cron "resyncOnInstall") }}
 {{- $resyncOnUpgrade := ternary .Values.workload.cron.resyncOnUpgrade true (hasKey .Values.workload.cron "resyncOnUpgrade") }}
-{{- if and (eq .Values.workload.kind "CronJob") (or $resyncOnInstall $resyncOnUpgrade) }}
+{{- $runOnInstall := and (eq .Values.workload.kind "CronJob") .Release.IsInstall $resyncOnInstall }}
+{{- $runOnUpgrade := and (eq .Values.workload.kind "CronJob") .Release.IsUpgrade $resyncOnUpgrade }}
+{{- if or $runOnInstall $runOnUpgrade }}
 {{- $jobName := (print (randAlphaNum 4) "-" .Release.Revision) | lower }}
 {{- $maxRunTimeSeconds := "" }}
 {{- if (.Values.workload.cron).resyncTimeoutMinutes }}
@@ -57,7 +59,19 @@ spec:
                   name: {{ include "port-ocean.cron.job-query-rbac-name" (list . "-sa-token") }}
                   key: token
           args:
-            - kubectl create job --from=cronjob/{{ include "port-ocean.cronJobName" . }} init-sync-{{ $jobName }} --token=$TOKEN
+            - |
+              {{- if $runOnInstall }}
+              kubectl create job --from=cronjob/{{ include "port-ocean.cronJobName" . }} init-sync-{{ $jobName }} --token=$TOKEN
+              {{- if .Values.incrementalSync.enabled }}
+              kubectl create job --from=cronjob/{{ include "port-ocean.incrementalSync.cronJobName" . }} init-incremental-{{ $jobName }} --token=$TOKEN
+              {{- end }}
+              {{- end }}
+              {{- if $runOnUpgrade }}
+              kubectl create job --from=cronjob/{{ include "port-ocean.cronJobName" . }} init-sync-{{ $jobName }} --token=$TOKEN
+              {{- if .Values.incrementalSync.enabled }}
+              kubectl create job --from=cronjob/{{ include "port-ocean.incrementalSync.cronJobName" . }} init-incremental-{{ $jobName }} --token=$TOKEN
+              {{- end }}
+              {{- end }}
       restartPolicy: Never
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/port-ocean/tests/installation-resync-job_test.yaml
+++ b/charts/port-ocean/tests/installation-resync-job_test.yaml
@@ -1,0 +1,69 @@
+suite: Installation resync job
+templates:
+  - templates/cron-job/installation-resync-job.yml
+tests:
+  - it: skips non-CronJob workloads
+    values:
+      - values/single.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: on install runs full and incremental jobs when enabled
+    values:
+      - values/hybrid-cron.yaml
+    set:
+      incrementalSync.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-install, post-upgrade
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: kubectl create job --from=cronjob/ocean-github-test-id-cron-job init-sync-
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: kubectl create job --from=cronjob/ocean-github-test-id-incr-cron init-incremental-
+
+  - it: on install skips all jobs when resyncOnInstall is false
+    values:
+      - values/hybrid-cron.yaml
+    set:
+      incrementalSync.enabled: true
+      workload.cron.resyncOnInstall: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: on upgrade skips all jobs when resyncOnUpgrade is false
+    values:
+      - values/hybrid-cron.yaml
+    release:
+      upgrade: true
+    set:
+      incrementalSync.enabled: true
+      workload.cron.resyncOnUpgrade: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: on upgrade runs jobs when resyncOnUpgrade is true
+    values:
+      - values/hybrid-cron.yaml
+    release:
+      upgrade: true
+    set:
+      incrementalSync.enabled: true
+      workload.cron.resyncOnInstall: false
+      workload.cron.resyncOnUpgrade: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: kubectl create job --from=cronjob/ocean-github-test-id-cron-job init-sync-
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: kubectl create job --from=cronjob/ocean-github-test-id-incr-cron init-incremental-


### PR DESCRIPTION
# Description

- Extend the existing `installation-resync-job` post-install/post-upgrade hook to also `kubectl create job` from the incremental CronJob when `incrementalSync.enabled` is true
- Gate install vs upgrade separately with `resyncOnInstall`/`resyncOnUpgrade` via `Release.IsInstall`/`Release.IsUpgrade` - incremental follows the same flags as full resync (no bypass when install resync is disabled).
- Consolidate `installation-resync` helm unittest coverage into five cases using hybrid-cron.yaml + set.

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

