### PR TITLE
Expose dedicated metrics port for ocean-gateway.

### DIFF
--- a/.github/workflows/validate-ocean-gateway.yml
+++ b/.github/workflows/validate-ocean-gateway.yml
@@ -62,6 +62,73 @@ jobs:
           fi
         }
 
+        assert_main_service_ports() {
+          local manifest=$1 service_name=$2 message=$3
+          local ports
+          ports=$(echo "$manifest" | awk -v name="$service_name" '
+            $0 ~ "^  name: " name "$" {found=1}
+            found && /^---$/ {exit}
+            found && /^    - name: / {print $3}
+          ')
+          if echo "$ports" | grep -qx 'metrics'; then
+            echo "FAIL: $message (main Service exposes metrics port)" >&2
+            exit 1
+          fi
+          if ! echo "$ports" | grep -qx 'http'; then
+            echo "FAIL: $message (main Service should expose http port)" >&2
+            exit 1
+          fi
+        }
+
+        assert_metrics_service_clusterip() {
+          local manifest=$1 service_name=$2 message=$3
+          local service_type
+          service_type=$(echo "$manifest" | awk -v name="$service_name" '
+            $0 ~ "^  name: " name "$" {found=1}
+            found && /^  type: / {print $2; exit}
+          ')
+          if [ "$service_type" != "ClusterIP" ]; then
+            echo "FAIL: $message (metrics Service type is ${service_type:-unset}, expected ClusterIP)" >&2
+            exit 1
+          fi
+        }
+
+        assert_metrics_service_port_block() {
+          local manifest=$1 service_name=$2 expected_port=$3 message=$4
+          local block
+          block=$(echo "$manifest" | awk -v name="$service_name" '
+            $0 ~ "^  name: " name "$" {found=1}
+            found {print}
+            found && /^---$/ {exit}
+          ')
+          echo "$block" | grep -q '^    - name: metrics$' || {
+            echo "FAIL: $message (metrics Service missing port name: metrics)" >&2
+            exit 1
+          }
+          echo "$block" | grep -q "^      port: ${expected_port}$" || {
+            echo "FAIL: $message (metrics Service port should be ${expected_port})" >&2
+            exit 1
+          }
+          echo "$block" | grep -q '^      targetPort: metrics$' || {
+            echo "FAIL: $message (metrics Service targetPort should be metrics)" >&2
+            exit 1
+          }
+        }
+
+        assert_deployment_metrics_port() {
+          local manifest=$1 expected_port=$2 message=$3
+          local block
+          block=$(echo "$manifest" | awk '/^kind: Deployment$/,/^---$/')
+          echo "$block" | grep -q '^            - name: metrics$' || {
+            echo "FAIL: $message (Deployment missing metrics container port name)" >&2
+            exit 1
+          }
+          echo "$block" | grep -q "^              containerPort: ${expected_port}$" || {
+            echo "FAIL: $message (Deployment metrics containerPort should be ${expected_port})" >&2
+            exit 1
+          }
+        }
+
         echo "=== External Redis (chart-managed Secret) ==="
         external_manifest=$(helm template external . \
           --set redis.url=redis:6379 \
@@ -82,16 +149,36 @@ jobs:
           "readiness probe should hit /healthz"
         assert_contains "$external_manifest" 'METRICS_LISTEN_ADDR: ":9100"' \
           "ConfigMap should set metrics listen address"
-        assert_contains "$external_manifest" 'name: metrics' \
+        assert_deployment_metrics_port "$external_manifest" 9100 \
           "Deployment should expose the metrics container port"
-        assert_contains "$external_manifest" 'containerPort: 9100' \
-          "Deployment metrics containerPort should default to 9100"
+        assert_contains "$external_manifest" 'name: external-ocean-gateway-metrics' \
+          "chart should create a dedicated metrics Service"
+        assert_metrics_service_clusterip "$external_manifest" 'external-ocean-gateway-metrics' \
+          "metrics Service should always be ClusterIP"
+        assert_metrics_service_port_block "$external_manifest" 'external-ocean-gateway-metrics' 9100 \
+          "metrics Service should wire port 9100 to targetPort metrics"
+        assert_main_service_ports "$external_manifest" 'external-ocean-gateway' \
+          "main Service should only expose the HTTP port"
         assert_contains "$external_manifest" 'serviceAccountName: default' \
           "Deployment should use the namespace default ServiceAccount when serviceAccount.create is false"
         assert_not_contains "$external_manifest" 'kind: ServiceAccount' \
           "ServiceAccount should not be created when serviceAccount.create is false"
         assert_not_contains "$external_manifest" 'name: wait-for-redis' \
           "external Redis should not deploy the wait-for-redis init container"
+
+        echo "=== LoadBalancer Service (metrics not publicly exposed) ==="
+        lb_manifest=$(helm template lb . \
+          --set redis.url=redis:6379 \
+          --set service.type=LoadBalancer)
+        echo "$lb_manifest" | kubectl apply --dry-run=client -f -
+        assert_contains "$lb_manifest" 'name: lb-ocean-gateway-metrics' \
+          "LoadBalancer install should still create a dedicated metrics Service"
+        assert_metrics_service_clusterip "$lb_manifest" 'lb-ocean-gateway-metrics' \
+          "metrics Service should stay ClusterIP when main Service is LoadBalancer"
+        assert_metrics_service_port_block "$lb_manifest" 'lb-ocean-gateway-metrics' 9100 \
+          "metrics Service should wire port 9100 to targetPort metrics"
+        assert_main_service_ports "$lb_manifest" 'lb-ocean-gateway' \
+          "LoadBalancer Service should only expose the HTTP port"
 
         echo "=== Dedicated ServiceAccount (opt-in) ==="
         sa_manifest=$(helm template sa . \

--- a/.github/workflows/validate-ocean-gateway.yml
+++ b/.github/workflows/validate-ocean-gateway.yml
@@ -80,6 +80,12 @@ jobs:
           "liveness probe should use tcpSocket (no Redis ping)"
         assert_contains "$external_manifest" 'path: /healthz' \
           "readiness probe should hit /healthz"
+        assert_contains "$external_manifest" 'METRICS_LISTEN_ADDR: ":9100"' \
+          "ConfigMap should set metrics listen address"
+        assert_contains "$external_manifest" 'name: metrics' \
+          "Deployment should expose the metrics container port"
+        assert_contains "$external_manifest" 'containerPort: 9100' \
+          "Deployment metrics containerPort should default to 9100"
         assert_contains "$external_manifest" 'serviceAccountName: default' \
           "Deployment should use the namespace default ServiceAccount when serviceAccount.create is false"
         assert_not_contains "$external_manifest" 'kind: ServiceAccount' \

--- a/charts/ocean-gateway/Chart.yaml
+++ b/charts/ocean-gateway/Chart.yaml
@@ -5,7 +5,7 @@ description: >
   Accepts webhook events and writes them synchronously to per-integration
   Redis streams, which Ocean integrations consume via XREADGROUP.
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "1.0.0"
 home: https://getport.io/
 sources:

--- a/charts/ocean-gateway/README.md
+++ b/charts/ocean-gateway/README.md
@@ -102,9 +102,9 @@ The following table lists the main configuration parameters and default values.
 | `stream.maxLen` | Approx `MAXLEN` per stream (ignored when `eventTTL` > 0) | `0` |
 | `write.maxRetries` | Per-request `XADD` retries before returning 503 | `2` |
 | `write.backoffBase` | Initial retry backoff | `"50ms"` |
-| `service.type` | Kubernetes Service type | `ClusterIP` |
-| `service.port` | Service and container HTTP port | `8080` |
-| `metrics.port` | Dedicated metrics listener and Service port | `9100` |
+| `service.type` | Kubernetes Service type for webhooks (`LoadBalancer`/`NodePort` publish every port on the main Service) | `ClusterIP` |
+| `service.port` | Main Service and container HTTP port (used by Ingress when enabled) | `8080` |
+| `metrics.port` | Metrics listener and `*-metrics` ClusterIP Service port (cluster-internal; not on the main Service) | `9100` |
 | `ingress.enabled` | Enable Ingress for external webhook providers | `false` |
 | `ingress.className` | Ingress class name | `""` |
 | `ingress.annotations` | Ingress annotations | `{}` |

--- a/charts/ocean-gateway/README.md
+++ b/charts/ocean-gateway/README.md
@@ -104,6 +104,7 @@ The following table lists the main configuration parameters and default values.
 | `write.backoffBase` | Initial retry backoff | `"50ms"` |
 | `service.type` | Kubernetes Service type | `ClusterIP` |
 | `service.port` | Service and container HTTP port | `8080` |
+| `metrics.port` | Dedicated metrics listener and Service port | `9100` |
 | `ingress.enabled` | Enable Ingress for external webhook providers | `false` |
 | `ingress.className` | Ingress class name | `""` |
 | `ingress.annotations` | Ingress annotations | `{}` |

--- a/charts/ocean-gateway/templates/NOTES.txt
+++ b/charts/ocean-gateway/templates/NOTES.txt
@@ -30,7 +30,8 @@ Health check:
 
 Metrics (Prometheus):
 
-  curl http://localhost:{{ .Values.service.port }}/metrics
+  kubectl port-forward svc/{{ include "ocean-gateway.fullname" . }} {{ .Values.metrics.port }}:{{ .Values.metrics.port }} -n {{ .Release.Namespace }}
+  curl http://localhost:{{ .Values.metrics.port }}/metrics
 
 Producer contract:
   - 202 Accepted  → event is durably in the Redis stream

--- a/charts/ocean-gateway/templates/NOTES.txt
+++ b/charts/ocean-gateway/templates/NOTES.txt
@@ -28,9 +28,9 @@ Health check:
   kubectl port-forward svc/{{ include "ocean-gateway.fullname" . }} {{ .Values.service.port }} -n {{ .Release.Namespace }}
   curl http://localhost:{{ .Values.service.port }}/healthz
 
-Metrics (Prometheus):
+Metrics (Prometheus, cluster-internal via *-metrics Service):
 
-  kubectl port-forward svc/{{ include "ocean-gateway.fullname" . }} {{ .Values.metrics.port }}:{{ .Values.metrics.port }} -n {{ .Release.Namespace }}
+  kubectl port-forward svc/{{ include "ocean-gateway.fullname" . }}-metrics {{ .Values.metrics.port }}:{{ .Values.metrics.port }} -n {{ .Release.Namespace }}
   curl http://localhost:{{ .Values.metrics.port }}/metrics
 
 Producer contract:

--- a/charts/ocean-gateway/templates/configmap.yaml
+++ b/charts/ocean-gateway/templates/configmap.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "ocean-gateway.labels" . | nindent 4 }}
 data:
   LISTEN_ADDR: ":{{ .Values.service.port }}"
+  METRICS_LISTEN_ADDR: ":{{ .Values.metrics.port }}"
   {{- if not .Values.redis.existingSecret }}
   REDIS_LIVE_EVENTS_URL: {{ include "ocean-gateway.redisUrl" . | quote }}
   REDIS_LIVE_EVENTS_ENABLE_TLS: {{ .Values.redis.tls.enabled | toString | quote }}

--- a/charts/ocean-gateway/templates/deployment.yaml
+++ b/charts/ocean-gateway/templates/deployment.yaml
@@ -88,6 +88,9 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+            - name: metrics
+              containerPort: {{ .Values.metrics.port }}
+              protocol: TCP
           envFrom:
             - configMapRef:
                 name: {{ include "ocean-gateway.configMapName" . }}

--- a/charts/ocean-gateway/templates/metrics-service.yaml
+++ b/charts/ocean-gateway/templates/metrics-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ocean-gateway.fullname" . }}-metrics
+  labels:
+    {{- include "ocean-gateway.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "ocean-gateway.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: metrics
+      protocol: TCP
+      port: {{ .Values.metrics.port }}
+      targetPort: metrics

--- a/charts/ocean-gateway/templates/service.yaml
+++ b/charts/ocean-gateway/templates/service.yaml
@@ -15,9 +15,5 @@ spec:
       protocol: TCP
       port: {{ .Values.service.port }}
       targetPort: http
-    - name: metrics
-      protocol: TCP
-      port: {{ .Values.metrics.port }}
-      targetPort: metrics
   selector:
     {{- include "ocean-gateway.selectorLabels" . | nindent 4 }}

--- a/charts/ocean-gateway/templates/service.yaml
+++ b/charts/ocean-gateway/templates/service.yaml
@@ -15,5 +15,9 @@ spec:
       protocol: TCP
       port: {{ .Values.service.port }}
       targetPort: http
+    - name: metrics
+      protocol: TCP
+      port: {{ .Values.metrics.port }}
+      targetPort: metrics
   selector:
     {{- include "ocean-gateway.selectorLabels" . | nindent 4 }}

--- a/charts/ocean-gateway/values.yaml
+++ b/charts/ocean-gateway/values.yaml
@@ -126,6 +126,11 @@ service:
   port: 8080
   annotations: {}
 
+# ── Metrics ───────────────────────────────────────────────────────────────────
+# Dedicated HTTP listener for Prometheus metrics (not exposed via Ingress).
+metrics:
+  port: 9100
+
 # ── Ingress ───────────────────────────────────────────────────────────────────
 # Expose the gateway to external webhook providers. Use path `/` (Prefix) so
 # all /live-events/{uuid}/integration/... routes reach the gateway.

--- a/charts/ocean-gateway/values.yaml
+++ b/charts/ocean-gateway/values.yaml
@@ -127,7 +127,9 @@ service:
   annotations: {}
 
 # ── Metrics ───────────────────────────────────────────────────────────────────
-# Dedicated HTTP listener for Prometheus metrics (not exposed via Ingress).
+# Dedicated HTTP listener for Prometheus. Exposed via a separate *-metrics
+# ClusterIP Service so metrics stay cluster-internal when service.type is
+# LoadBalancer or NodePort (every port on those Services is published).
 metrics:
   port: 9100
 


### PR DESCRIPTION
The gateway now serves Prometheus metrics on a separate listener (default :9100). Wire METRICS_LISTEN_ADDR, container port, and Service port so scrapers can target metrics without hitting the webhook HTTP port.

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

