### PR TITLE
chore(port-agent): bump to v0.8.12

### DIFF
--- a/charts/port-agent/Chart.yaml
+++ b/charts/port-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: port-agent
 description: A Helm chart for Port Agent
 type: application
-version: 0.8.15
-appVersion: "v0.8.10"
+version: 0.8.16
+appVersion: "v0.8.12"
 home: https://getport.io/
 sources:
   - https://github.com/port-labs/port-agent


### PR DESCRIPTION
## Summary
- Bump port-agent chart to `0.8.16` and appVersion to `v0.8.12` (from `v0.8.10`)
- Pulls in polling/webhook fix to preserve invocation method body (#85) and related test defaults (#86)

## Test plan
- [ ] Confirm `Chart.yaml` shows `version: 0.8.16` and `appVersion: "v0.8.12"`
- [ ] `helm template test charts/port-agent --set env.normal.PORT_ORG_ID=test` renders successfully
- [ ] Image resolves to `ghcr.io/port-labs/port-agent:v0.8.12` when `image.tag` is unset


Made with [Cursor](https://cursor.com)