### PR TITLE
[CI] Added scripts to automate port-ocean version bump

### DIFF
--- a/.github/scripts/bump-ocean-saas-chart-wrap.sh
+++ b/.github/scripts/bump-ocean-saas-chart-wrap.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Bump ocean-saas-chart-wrap in an infra-apps checkout to a released port-ocean version.
+# Usage: bump-ocean-saas-chart-wrap.sh <infra-apps-root> <port-ocean-version>
+set -euo pipefail
+
+INFRA_APPS_ROOT="${1:?infra-apps root is required}"
+export PORT_OCEAN_VERSION="${2:?port-ocean version is required}"
+CHART_DIR="${INFRA_APPS_ROOT}/internal-charts/ocean-saas-chart-wrap"
+CHART_FILE="${CHART_DIR}/Chart.yaml"
+HELM_REPO_NAME="port-labs"
+HELM_REPO_URL="https://port-labs.github.io/helm-charts/"
+MAX_ATTEMPTS="${HELM_REPO_WAIT_ATTEMPTS:-24}"
+SLEEP_SECONDS="${HELM_REPO_WAIT_SECONDS:-15}"
+
+if [[ ! -f "${CHART_FILE}" ]]; then
+  echo "::error::Chart.yaml not found at ${CHART_FILE}"
+  exit 1
+fi
+
+current_version="$(yq '.dependencies[] | select(.name == "port-ocean") | .version' "${CHART_FILE}")"
+
+if [[ -z "${current_version}" ]]; then
+  echo "::error::Could not read port-ocean dependency version from ${CHART_FILE}"
+  exit 1
+fi
+
+echo "Current ocean-saas-chart-wrap port-ocean dependency: ${current_version}"
+echo "Target port-ocean version: ${PORT_OCEAN_VERSION}"
+
+if [[ "${PORT_OCEAN_VERSION}" == *rc* ]]; then
+  echo "Skipping RC version ${PORT_OCEAN_VERSION}."
+  echo "changed=false" >> "${GITHUB_OUTPUT:-/dev/null}"
+  exit 0
+fi
+
+if [[ "${current_version}" == "${PORT_OCEAN_VERSION}" ]]; then
+  echo "Already at ${PORT_OCEAN_VERSION}; nothing to do."
+  echo "changed=false" >> "${GITHUB_OUTPUT:-/dev/null}"
+  exit 0
+fi
+
+if [[ "$(printf '%s\n%s\n' "${current_version}" "${PORT_OCEAN_VERSION}" | sort -V | tail -1)" == "${current_version}" ]]; then
+  echo "Wrap chart is already ahead (${current_version} > ${PORT_OCEAN_VERSION}); skipping."
+  echo "changed=false" >> "${GITHUB_OUTPUT:-/dev/null}"
+  exit 0
+fi
+
+# Patch-bump the wrap chart's own version (0.1.12 -> 0.1.13). infra-apps
+# requires this so the wrapper is treated as a new chart release, matching
+# the manual bump PRs.
+yq -i '.version |= (split(".") | .[-1] |= ((. | tonumber) + 1 | tostring) | join("."))' "${CHART_FILE}"
+# Pin the port-ocean subchart to the version that was just released.
+yq -i '(.dependencies[] | select(.name == "port-ocean")).version = strenv(PORT_OCEAN_VERSION)' "${CHART_FILE}"
+
+echo "Updated ${CHART_FILE}:"
+grep -n -E '^(version:|  - name: port-ocean|    version:)' "${CHART_FILE}" || true
+
+# Chart.lock digest comes from the published chart, not Chart.yaml. The helm
+# repo is GitHub Pages, which can lag the GitHub Release by a minute or two,
+# so wait until this exact version is queryable before locking.
+helm repo add "${HELM_REPO_NAME}" "${HELM_REPO_URL}" --force-update
+
+found=false
+for attempt in $(seq 1 "${MAX_ATTEMPTS}"); do
+  helm repo update "${HELM_REPO_NAME}"
+  # helm search prints a header row; awk drops it and grep requires an exact
+  # version match so 0.23.3 does not succeed when we asked for 0.23.30.
+  if helm search repo "${HELM_REPO_NAME}/port-ocean" --version "${PORT_OCEAN_VERSION}" --versions |
+    awk 'NR > 1 { print $2 }' |
+    grep -Fxq "${PORT_OCEAN_VERSION}"; then
+    found=true
+    break
+  fi
+  echo "Waiting for port-ocean ${PORT_OCEAN_VERSION} in ${HELM_REPO_URL} (attempt ${attempt}/${MAX_ATTEMPTS})"
+  sleep "${SLEEP_SECONDS}"
+done
+
+if [[ "${found}" != true ]]; then
+  echo "::error::port-ocean ${PORT_OCEAN_VERSION} did not appear in ${HELM_REPO_URL}"
+  exit 1
+fi
+
+# Refresh Chart.lock (digest + generated timestamp) from the live repo.
+helm dependency update "${CHART_DIR}"
+# helm dependency update also downloads charts/port-ocean-*.tgz. That tarball
+# is not part of the wrap-chart contract and must not land in the PR.
+rm -f "${CHART_DIR}/charts/"port-ocean-*.tgz
+
+# Tell the workflow a PR is needed. GITHUB_OUTPUT is unset when this script
+# is run locally, so fall back to /dev/null.
+echo "changed=true" >> "${GITHUB_OUTPUT:-/dev/null}"
+echo "Bumped ocean-saas-chart-wrap to port-ocean ${PORT_OCEAN_VERSION}"

--- a/.github/workflows/bump-ocean-saas-after-release.yml
+++ b/.github/workflows/bump-ocean-saas-after-release.yml
@@ -1,0 +1,171 @@
+# After port-ocean is released from this repo, open a PR in infra-apps that
+# bumps internal-charts/ocean-saas-chart-wrap (Chart.yaml + Chart.lock).
+# A follow-up workflow_run is used so GitHub Pages can serve the new chart
+# and so Release RC (pull_request) runs are ignored.
+name: Bump Ocean SaaS after release
+
+on:
+  workflow_run:
+    workflows: ["Release Charts"]
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      port_ocean_version:
+        description: port-ocean chart version to bump to (defaults to charts/port-ocean/Chart.yaml)
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bump-ocean-saas-after-release
+  cancel-in-progress: false
+
+jobs:
+  bump-ocean-saas:
+    name: Open infra-apps PR for ocean-saas-chart-wrap
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_branch == 'main' &&
+        contains(fromJSON('["push","workflow_dispatch"]'), github.event.workflow_run.event)
+      )
+
+    steps:
+      - name: Checkout helm-charts
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          path: helm-charts
+
+      - name: Resolve port-ocean version
+        id: ver
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.port_ocean_version }}
+        run: |
+          set -euo pipefail
+          VERSION="${INPUT_VERSION}"
+          if [[ -z "${VERSION}" ]]; then
+            VERSION="$(awk '$1 == "version:" { print $2; exit }' helm-charts/charts/port-ocean/Chart.yaml)"
+          fi
+          if [[ -z "${VERSION}" ]]; then
+            echo "::error::Could not resolve port-ocean version"
+            exit 1
+          fi
+          if [[ "${VERSION}" == *rc* ]]; then
+            echo "skip=true" >> "${GITHUB_OUTPUT}"
+            echo "Skipping RC version ${VERSION}"
+            exit 0
+          fi
+          echo "skip=false" >> "${GITHUB_OUTPUT}"
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "Resolved port-ocean version ${VERSION}"
+
+      - name: Checkout infra-apps
+        if: steps.ver.outputs.skip != 'true'
+        uses: actions/checkout@v5
+        with:
+          repository: port-labs/infra-apps
+          token: ${{ secrets.PORT_MACHINE_USER_GITHUB_TOKEN }}
+          path: infra-apps
+
+      - name: Install Helm
+        if: steps.ver.outputs.skip != 'true'
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
+
+      - name: Install yq
+        if: steps.ver.outputs.skip != 'true'
+        uses: dcarbone/install-yq-action@v1.3.1
+        with:
+          force: true
+
+      - name: Bump ocean-saas-chart-wrap
+        if: steps.ver.outputs.skip != 'true'
+        id: bump
+        env:
+          PORT_OCEAN_VERSION: ${{ steps.ver.outputs.version }}
+        run: bash helm-charts/.github/scripts/bump-ocean-saas-chart-wrap.sh infra-apps "${PORT_OCEAN_VERSION}"
+
+      - name: Open pull request
+        if: steps.ver.outputs.skip != 'true' && steps.bump.outputs.changed == 'true'
+        id: open_pr
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.PORT_MACHINE_USER_GITHUB_TOKEN }}
+          path: infra-apps
+          base: main
+          branch: automated/bump-ocean-saas-port-ocean-${{ steps.ver.outputs.version }}
+          delete-branch: true
+          commit-message: "chore(ocean-saas): bump port-ocean to ${{ steps.ver.outputs.version }}"
+          committer: port-gitops[bot] <port-gitops[bot]@users.noreply.github.com>
+          author: port-gitops[bot] <port-gitops[bot]@users.noreply.github.com>
+          title: "chore(ocean-saas): bump port-ocean to ${{ steps.ver.outputs.version }}"
+          add-paths: |
+            internal-charts/ocean-saas-chart-wrap/Chart.yaml
+            internal-charts/ocean-saas-chart-wrap/Chart.lock
+          body: |
+            Automated bump after `port-ocean` ${{ steps.ver.outputs.version }} was released from `port-labs/helm-charts`.
+
+            ## Summary
+            - Set `ocean-saas-chart-wrap` dependency `port-ocean` to `${{ steps.ver.outputs.version }}`
+            - Patch-bump the wrap chart version
+            - Regenerate `Chart.lock` via `helm dependency update`
+
+            ## Source
+            - Helm charts commit: ${{ github.event.workflow_run.head_sha || github.sha }}
+            - Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            - Task: [task_tj99o5](https://app.getport.io/org_ukrSy0JXDGngBGUH/taskEntity?identifier=task_tj99o5)
+
+            ## Test plan
+            - [ ] `helm dependency update`
+            - [ ] `helm lint .`
+            - [ ] Review wrap chart version bump and `Chart.lock`
+
+      - name: Notify Slack
+        if: >
+          steps.open_pr.outputs.pull-request-url != '' &&
+          secrets.OCEAN_SLACK_WEBHOOK != ''
+        continue-on-error: true
+        uses: fjogeleit/http-request-action@v2
+        with:
+          url: ${{ secrets.OCEAN_SLACK_WEBHOOK }}
+          method: POST
+          customHeaders: '{"Content-Type": "application/json"}'
+          data: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Ocean SaaS port-ocean bump is ready for review!* :ocean:"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Version:* `${{ steps.ver.outputs.version }}`"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Pull request:* <${{ steps.open_pr.outputs.pull-request-url }}|Review and merge>"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Workflow run:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/bump-ocean-saas-after-release.yml
+++ b/.github/workflows/bump-ocean-saas-after-release.yml
@@ -28,6 +28,9 @@ jobs:
     name: Open infra-apps PR for ocean-saas-chart-wrap
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      # secrets cannot be referenced in `if:` — copy to env first.
+      OCEAN_SLACK_WEBHOOK: ${{ secrets.OCEAN_SLACK_WEBHOOK }}
     if: >
       github.event_name == 'workflow_dispatch' ||
       (
@@ -127,9 +130,7 @@ jobs:
             - [ ] Review wrap chart version bump and `Chart.lock`
 
       - name: Notify Slack
-        if: >
-          steps.open_pr.outputs.pull-request-url != '' &&
-          secrets.OCEAN_SLACK_WEBHOOK != ''
+        if: steps.open_pr.outputs.pull-request-url != '' && env.OCEAN_SLACK_WEBHOOK != ''
         continue-on-error: true
         uses: fjogeleit/http-request-action@v2
         with:


### PR DESCRIPTION
# Description

What - Open an automatic PR to bump script in infra repo
Why - Needing to do it manually can cause potential version bump misses 
How - Workflow that runs on right after Release Charts that bumps the version and opens a PR

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

