### PR TITLE
chore(port-k8s-exporter): bump chart to v0.7.10

### DIFF
--- a/charts/port-k8s-exporter/Chart.yaml
+++ b/charts/port-k8s-exporter/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: port-k8s-exporter
 description: A Helm chart for Port Kubernetes Exporter
 type: application
-version: 0.3.32
-appVersion: "0.7.9"
+version: 0.3.33
+appVersion: "0.7.10"
 home: https://getport.io/
 sources:
   - https://github.com/port-labs/port-k8s-exporter


### PR DESCRIPTION
Automated bump after port-k8s-exporter release.
- Chart version: 0.7.10
- App/image version: 0.7.10