### PR TITLE
Make Ocean probe timings explicit in values.yaml (readiness initialDelay 5s)

### DIFF
--- a/charts/port-ocean/Chart.yaml
+++ b/charts/port-ocean/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-ocean
 description: A Helm chart for Port Ocean integrations
 type: application
-version: 0.23.5
+version: 0.23.6
 appVersion: "0.1.0"
 home: https://getport.io/
 sources:

--- a/charts/port-ocean/templates/actions-processor/deployment.yaml
+++ b/charts/port-ocean/templates/actions-processor/deployment.yaml
@@ -94,22 +94,22 @@ spec:
           httpGet:
             path: /health/live
             port: {{.Values.actionsProcessor.service.port}}
-          initialDelaySeconds: {{ default 30 .Values.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ default 10 .Values.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ default 5 .Values.livenessProbe.timeoutSeconds }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           successThreshold: 1
-          failureThreshold: {{ default 3 .Values.livenessProbe.failureThreshold }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
         {{- end }}
         {{- if (.Values.readinessProbe).enabled}}
         readinessProbe:
           httpGet:
             path: /health/ready
             port: {{.Values.actionsProcessor.service.port}}
-          initialDelaySeconds: {{ default 5 .Values.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ default 5 .Values.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ default 5 .Values.readinessProbe.timeoutSeconds }}
-          successThreshold: {{ default 1 .Values.readinessProbe.successThreshold }}
-          failureThreshold: {{ default 5 .Values.readinessProbe.failureThreshold }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
         {{- end }}
       {{- if .Values.actionsProcessor.worker.extraContainers }}
       {{- tpl (toYaml .Values.actionsProcessor.worker.extraContainers) . | nindent 6 }}

--- a/charts/port-ocean/templates/deployment-live-events.yaml
+++ b/charts/port-ocean/templates/deployment-live-events.yaml
@@ -114,7 +114,7 @@ spec:
           httpGet:
             path: /health/ready
             port: {{.Values.liveEvents.service.port}}
-          initialDelaySeconds: {{ default 30 .Values.readinessProbe.initialDelaySeconds }}
+          initialDelaySeconds: {{ default 5 .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ default 10 .Values.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ default 5 .Values.readinessProbe.timeoutSeconds }}
           successThreshold: {{ default 2 .Values.readinessProbe.successThreshold }}

--- a/charts/port-ocean/templates/deployment-live-events.yaml
+++ b/charts/port-ocean/templates/deployment-live-events.yaml
@@ -103,22 +103,22 @@ spec:
           httpGet:
             path: /health/live
             port: {{.Values.liveEvents.service.port}}
-          initialDelaySeconds: {{ default 30 .Values.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ default 10 .Values.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ default 5 .Values.livenessProbe.timeoutSeconds }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           successThreshold: 1
-          failureThreshold: {{ default 3 .Values.livenessProbe.failureThreshold }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
         {{- end }}
         {{- if (.Values.readinessProbe).enabled}}
         readinessProbe:
           httpGet:
             path: /health/ready
             port: {{.Values.liveEvents.service.port}}
-          initialDelaySeconds: {{ default 5 .Values.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ default 10 .Values.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ default 5 .Values.readinessProbe.timeoutSeconds }}
-          successThreshold: {{ default 2 .Values.readinessProbe.successThreshold }}
-          failureThreshold: {{ default 3 .Values.readinessProbe.failureThreshold }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
         {{- end }}
       {{- if .Values.liveEvents.worker.extraContainers }}
       {{- tpl (toYaml .Values.liveEvents.worker.extraContainers) . | nindent 6 }}

--- a/charts/port-ocean/templates/deployment.yaml
+++ b/charts/port-ocean/templates/deployment.yaml
@@ -101,22 +101,22 @@ spec:
           httpGet:
             path: /health/live
             port: {{.Values.service.port}}
-          initialDelaySeconds: {{ default 30 .Values.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ default 10 .Values.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ default 5 .Values.livenessProbe.timeoutSeconds }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           successThreshold: 1
-          failureThreshold: {{ default 3 .Values.livenessProbe.failureThreshold }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
         {{- end }}
         {{- if (.Values.readinessProbe).enabled}}
         readinessProbe:
           httpGet:
             path: /health/ready
             port: {{.Values.service.port}}
-          initialDelaySeconds: {{ default 5 .Values.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ default 5 .Values.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ default 5 .Values.readinessProbe.timeoutSeconds }}
-          successThreshold: {{ default 1 .Values.readinessProbe.successThreshold }}
-          failureThreshold: {{ default 5 .Values.readinessProbe.failureThreshold }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
         {{- end }}
       {{- if .Values.workload.deployment.extraContainers }}
       {{- tpl (toYaml .Values.workload.deployment.extraContainers) . | nindent 6 }}

--- a/charts/port-ocean/tests/actions-processor-deployment_test.yaml
+++ b/charts/port-ocean/tests/actions-processor-deployment_test.yaml
@@ -18,6 +18,21 @@ tests:
       - equal:
           path: metadata.name
           value: ocean-github-test-id-ap-deployment
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
+          value: 30
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.periodSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.successThreshold
+          value: 1
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.failureThreshold
+          value: 5
 
   - it: renders for hybrid architecture
     values:

--- a/charts/port-ocean/tests/live-events-deployment_test.yaml
+++ b/charts/port-ocean/tests/live-events-deployment_test.yaml
@@ -18,6 +18,21 @@ tests:
       - equal:
           path: metadata.name
           value: ocean-github-test-id-le-deployment
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
+          value: 30
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.periodSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.successThreshold
+          value: 1
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.failureThreshold
+          value: 5
 
   - it: renders for hybrid architecture
     values:

--- a/charts/port-ocean/tests/main-deployment_test.yaml
+++ b/charts/port-ocean/tests/main-deployment_test.yaml
@@ -11,6 +11,21 @@ tests:
       - equal:
           path: metadata.name
           value: ocean-github-test-id-deployment
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
+          value: 30
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.periodSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.successThreshold
+          value: 1
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.failureThreshold
+          value: 5
 
   - it: renders deployment annotations
     values:

--- a/charts/port-ocean/values.yaml
+++ b/charts/port-ocean/values.yaml
@@ -252,18 +252,18 @@ liveEvents:
 
 livenessProbe:
   enabled: true
-#  initialDelaySeconds: 30
-#  periodSeconds: 10
-#  timeoutSeconds: 5
-#  failureThreshold: 3
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
 
 readinessProbe:
   enabled: true
-#  initialDelaySeconds: 30
-#  periodSeconds: 10
-#  timeoutSeconds: 5
-#  failureThreshold: 3
-#  successThreshold: 2
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 5
+  failureThreshold: 5
+  successThreshold: 1
 
 processingMode: dsp
 


### PR DESCRIPTION
## Summary
- Make liveness/readiness probe timings **explicit in `values.yaml`** and remove template `default ...` fallbacks
- Unify probe settings across main, live-events, and actions-processor deployments
- Default readiness `initialDelaySeconds` is **5** (was effectively 30 for live-events via template default)
- Chart version `0.23.6`

**Port task:** https://app.getport.io/taskEntity?identifier=task_tkmdit  
**Companion:** [port-labs/ocean#3878](https://github.com/port-labs/ocean/pull/3878) — `/health/ready` returns `503` until Ocean startup completes

### Default probe values

| Probe | initialDelay | period | timeout | failureThreshold | successThreshold |
|---|---|---|---|---|---|
| Liveness | 30s | 10s | 5s | 3 | 1 (hardcoded) |
| Readiness | 5s | 5s | 5s | 5 | 1 |

### Why readiness `initialDelaySeconds: 5` is enough
With a real ready signal from Ocean, `initialDelaySeconds` only delays the **first** probe — it does **not** require the app to be ready within 5s.

- Before Ocean is ready → probes fail → pod stays **NotReady** (no traffic, **no restart**)
- When `/health/ready` returns 200 → pod becomes Ready
- Exceeding readiness `failureThreshold` only marks the pod NotReady; it keeps probing and can become Ready later
- Long Port provisioning (40s–1m) is fine for readiness; the risk of **restarts** is liveness (~60s grace with current defaults), not readiness delay

## Test plan
- [x] `helm lint charts/port-ocean`
- [x] `helm template` + `kubectl apply --dry-run=client` for all test values fixtures
- [x] Unittest assertions for rendered probe timings on main / live-events / actions-processor
- [ ] Merge + release Ocean core readiness change first
- [ ] Deploy and confirm Ready flips when `/health/ready` succeeds (fast when startup is short; waits when provisioning is slow) without unnecessary restarts