### PR TITLE
Explicitly Resolve Integration Config For Actions And Live Events ConfigMap

### DIFF
--- a/charts/port-ocean/Chart.yaml
+++ b/charts/port-ocean/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: port-ocean
 description: A Helm chart for Port Ocean integrations
 type: application
-version: 0.23.7
+version: 0.23.8
 appVersion: "0.1.0"
 home: https://getport.io/
 sources:

--- a/charts/port-ocean/templates/actions-processor/configmap.yaml
+++ b/charts/port-ocean/templates/actions-processor/configmap.yaml
@@ -29,7 +29,11 @@ data:
   {{- end }}
   {{- if .Values.integration.config }}
   {{- range $key, $value := .Values.integration.config }}
+  {{- if or (kindIs "map" $value) (kindIs "slice" $value) }}
+  OCEAN__INTEGRATION__CONFIG__{{ $key | snakecase | upper }}: {{ $value | toJson | quote }}
+  {{- else }}
   OCEAN__INTEGRATION__CONFIG__{{ $key | snakecase | upper }}: {{ $value | quote }}
+  {{- end }}
   {{- end }}
   {{- end }}
   {{- if .Values.liveEvents.baseUrl }}

--- a/charts/port-ocean/templates/configmap-live-events.yaml
+++ b/charts/port-ocean/templates/configmap-live-events.yaml
@@ -27,7 +27,11 @@ data:
   {{- end }}
   {{- if .Values.integration.config }}
   {{- range $key, $value := .Values.integration.config }}
+  {{- if or (kindIs "map" $value) (kindIs "slice" $value) }}
+  OCEAN__INTEGRATION__CONFIG__{{ $key | snakecase | upper }}: {{ $value | toJson | quote }}
+  {{- else }}
   OCEAN__INTEGRATION__CONFIG__{{ $key | snakecase | upper }}: {{ $value | quote }}
+  {{- end }}
   {{- end }}
   {{- end }}
   {{- if .Values.liveEvents.baseUrl }}

--- a/charts/port-ocean/tests/configmap-integration-config_test.yaml
+++ b/charts/port-ocean/tests/configmap-integration-config_test.yaml
@@ -1,0 +1,86 @@
+suite: Integration config JSON encoding
+tests:
+  - it: encodes list and map integration config as JSON on the main configmap
+    templates:
+      - templates/configmap.yaml
+    values:
+      - values/integration-config-json.yaml
+    asserts:
+      - equal:
+          path: data.OCEAN__INTEGRATION__CONFIG__EXCLUDED_TAGS
+          value: '["tr:restricted"]'
+      - equal:
+          path: data.OCEAN__INTEGRATION__CONFIG__NESTED
+          value: '{"foo":"bar"}'
+      - equal:
+          path: data.OCEAN__INTEGRATION__CONFIG__ORGANIZATION_URL
+          value: https://dev.azure.com/example
+
+  - it: encodes list and map integration config as JSON on the live-events configmap
+    templates:
+      - templates/configmap-live-events.yaml
+    values:
+      - values/integration-config-json.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: ocean-github-test-id-le-config
+      - equal:
+          path: data.OCEAN__INTEGRATION__CONFIG__EXCLUDED_TAGS
+          value: '["tr:restricted"]'
+      - equal:
+          path: data.OCEAN__INTEGRATION__CONFIG__NESTED
+          value: '{"foo":"bar"}'
+      - equal:
+          path: data.OCEAN__INTEGRATION__CONFIG__ORGANIZATION_URL
+          value: https://dev.azure.com/example
+
+  - it: does not render live-events configmap when the worker is disabled
+    templates:
+      - templates/configmap-live-events.yaml
+    values:
+      - values/single.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: encodes list and map integration config as JSON on the actions-processor configmap
+    templates:
+      - templates/actions-processor/configmap.yaml
+    values:
+      - values/integration-config-json.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: ocean-github-test-id-ap-config
+      - equal:
+          path: data.OCEAN__INTEGRATION__CONFIG__EXCLUDED_TAGS
+          value: '["tr:restricted"]'
+      - equal:
+          path: data.OCEAN__INTEGRATION__CONFIG__NESTED
+          value: '{"foo":"bar"}'
+      - equal:
+          path: data.OCEAN__INTEGRATION__CONFIG__ORGANIZATION_URL
+          value: https://dev.azure.com/example
+
+  - it: encodes list and map integration config as JSON on the incremental configmap
+    templates:
+      - templates/configmap-incremental.yaml
+    values:
+      - values/integration-config-json.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: data.OCEAN__INTEGRATION__CONFIG__EXCLUDED_TAGS
+          value: '["tr:restricted"]'
+      - equal:
+          path: data.OCEAN__INTEGRATION__CONFIG__NESTED
+          value: '{"foo":"bar"}'
+      - equal:
+          path: data.OCEAN__INTEGRATION__CONFIG__ORGANIZATION_URL
+          value: https://dev.azure.com/example

--- a/charts/port-ocean/tests/values/integration-config-json.yaml
+++ b/charts/port-ocean/tests/values/integration-config-json.yaml
@@ -1,0 +1,25 @@
+port:
+  clientId: test
+  clientSecret: test
+integration:
+  type: github
+  identifier: test-id
+  version: 0.1.0
+  config:
+    organizationUrl: https://dev.azure.com/example
+    excludedTags:
+      - "tr:restricted"
+    nested:
+      foo: bar
+workload:
+  kind: Deployment
+liveEvents:
+  worker:
+    enabled: true
+  baseUrl: http://le.example
+actionsProcessor:
+  enabled: true
+  worker:
+    enabled: true
+incrementalSync:
+  enabled: true


### PR DESCRIPTION
# Description

What - Encode list and map `integration.config` values as JSON in the live-events and actions-processor ConfigMaps, matching the main ConfigMap.

Why - Enabling live events crashed Ocean with a Pydantic `list_type` error: Helm `quote` turned lists like `excludedTags: ["tr:restricted"]` into the string `[tr:restricted]`. The same gap existed on the actions-processor ConfigMap.

How - Apply the existing `kindIs map/slice` + `toJson | quote` handling from `configmap.yaml`. Bump `port-ocean` to 0.23.8 and add helm-unittest coverage for list, map, and scalar config on the main, live-events, actions-processor, and incremental ConfigMaps.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)